### PR TITLE
stacktrace: Search through context for a valid location

### DIFF
--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -325,7 +325,14 @@ impl CallFrame {
     }
 
     pub fn last_resolved(&self, source_manager: &dyn SourceManager) -> Option<&ResolvedLocation> {
-        self.context.back().and_then(|op| op.resolve(source_manager))
+        // Search through context in reverse order to find the most recent op with a resolvable
+        // location.
+        for op in self.context.iter().rev() {
+            if let Some(resolved) = op.resolve(source_manager) {
+                return Some(resolved);
+            }
+        }
+        None
     }
 
     pub fn recent(&self) -> &VecDeque<OpDetail> {


### PR DESCRIPTION
Before this PR, the test from https://github.com/0xMiden/compiler/pull/810 looks as:

```bash
Stack Trace:
 `-> root_ns:root@1.0.0::init in <unavailable>:

Last 5 Instructions (of current frame):
 |   drop
 |   eq
 |   not
 |   drop
 |   pad
 `-> <error occured here>


Last 5 Instructions (any frame):
 |   end
 |   split
 |   span
 |   drop
 |   pad
 `-> <error occured here>


Last Known State (at most recent instruction which succeeded):
 | Operand Stack: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
Error:   x Main thread panicked.
  |-> at tests/integration/src/rust_masm_tests/debug_source_locations.rs:70:18
  `->   × program execution failed at step 184 (cycle 183): assertion failed at clock cycle 183 with error code: 0
```

after this workaround, it is:

```bash
Stack Trace:
 `-> root_ns:root@1.0.0::init in /Users/djtodorovic/projects/crypto/MIDEN/compiler/tests/rust-apps-wasm/rust-sdk/assert-debug-test/src/lib.rs:26:13:

Last 5 Instructions (of current frame):
 |   drop
 |   eq
 |   not
 |   drop
 |   pad
 `-> <error occured here>


Last 5 Instructions (any frame):
 |   end
 |   split
 |   span
 |   drop
 |   pad
 `-> <error occured here>


Last Known State (at most recent instruction which succeeded):
 | Operand Stack: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
Error:   x Main thread panicked.
  |-> at tests/integration/src/rust_masm_tests/debug_source_locations.rs:70:18
  `->   × program execution failed at step 184 (cycle 183): assertion failed at clock cycle 183 with error code: 0
          ╭─[/Users/djtodorovic/projects/crypto/MIDEN/compiler/tests/rust-apps-wasm/rust-sdk/assert-debug-test/src/lib.rs:26:13]
       25 │ pub fn entrypoint(x: u32) -> u32 {
       26 │     assert!(x > 100);
          ·             ▲
       27 │     x
          ╰────
```