### PR TITLE
tools: Add flamegraph subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1260,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
+dependencies = [
+ "ahash",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,7 +1664,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
  "serde",
@@ -1665,6 +1694,7 @@ dependencies = [
  "crossterm",
  "env_logger",
  "futures",
+ "inferno",
  "log",
  "miden-assembly",
  "miden-assembly-syntax",
@@ -1688,7 +1718,7 @@ name = "miden-debug-dap"
 version = "0.7.1"
 dependencies = [
  "fake",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2077,6 +2107,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -2728,7 +2768,7 @@ dependencies = [
  "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2741,6 +2781,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -2779,8 +2828,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2790,7 +2837,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2803,16 +2850,6 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3018,6 +3055,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3400,6 +3446,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strength_reduce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,14 @@ required-features = ["tui"]
 name = "println_multiple_prints"
 required-features = ["tui"]
 
+[[test]]
+name = "flamegraph_profile"
+required-features = ["flamegraph"]
+
 [features]
 default = ["tui", "dap"]
-tui = ["std", "dep:crossterm", "dep:env_logger", "dep:inferno", "dep:ratatui", "dep:tui-input", "dep:signal-hook", "dep:syntect", "miden-debug-engine/tui"]
+flamegraph = ["std", "dep:env_logger", "dep:inferno", "miden-debug-engine/tui"]
+tui = ["std", "flamegraph", "dep:crossterm", "dep:env_logger", "dep:ratatui", "dep:tui-input", "dep:signal-hook", "dep:syntect", "miden-debug-engine/tui"]
 repl = ["std", "dep:env_logger", "dep:rustyline", "miden-debug-engine/tui"]
 dap = ["miden-debug-engine/dap"]
 std = ["clap/std", "clap/env", "compact_str/std", "miden-assembly-syntax/std", "miden-debug-engine/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ required-features = ["tui"]
 
 [features]
 default = ["tui", "dap"]
-tui = ["std", "dep:crossterm", "dep:env_logger", "dep:ratatui", "dep:tui-input", "dep:signal-hook", "dep:syntect", "miden-debug-engine/tui"]
+tui = ["std", "dep:crossterm", "dep:env_logger", "dep:inferno", "dep:ratatui", "dep:tui-input", "dep:signal-hook", "dep:syntect", "miden-debug-engine/tui"]
 repl = ["std", "dep:env_logger", "dep:rustyline", "miden-debug-engine/tui"]
 dap = ["miden-debug-engine/dap"]
 std = ["clap/std", "clap/env", "compact_str/std", "miden-assembly-syntax/std", "miden-debug-engine/std"]
@@ -100,6 +100,7 @@ crossterm = { version = "0.29.0", optional = true, features = ["event-stream"] }
 compact_str = { version = "0.9", default-features = false }
 miden-debug-engine.workspace = true
 env_logger = { version = "0.11", optional = true }
+inferno = { version = "0.12", optional = true, default-features = false }
 log.workspace = true
 miden-assembly.workspace = true
 miden-assembly-syntax.workspace = true

--- a/crates/dap/src/lib.rs
+++ b/crates/dap/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! Our dummy server is going to read its input from a text file and write the output to stdout.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::fs::File;
 //! use std::io::{BufReader, BufWriter};
 //!
@@ -62,9 +62,9 @@
 //!   };
 //!   if let Command::Initialize(_) = req.command {
 //!     let rsp = req.success(
-//!       ResponseBody::Initialize(Some(types::Capabilities {
+//!       ResponseBody::Initialize(types::Capabilities {
 //!         ..Default::default()
-//!       })),
+//!       }),
 //!     );
 //!
 //!     // When you call respond, send_event etc. the message will be wrapped

--- a/crates/dap/src/types.rs
+++ b/crates/dap/src/types.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
 #[cfg(feature = "integration_testing")]
-use fake::{Dummy, Fake, Faker};
-#[cfg(feature = "integration_testing")]
-use rand::Rng;
+use fake::{Dummy, Fake, Faker, RngExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -225,10 +223,10 @@ struct ValueFaker;
 
 #[cfg(feature = "integration_testing")]
 impl Dummy<ValueFaker> for CustomValue {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ValueFaker, rng: &mut R) -> Self {
-        CustomValue(match rng.gen_range(0..=5) {
-            1 => Value::Bool(rng.r#gen()),
-            2 => Value::Number(serde_json::Number::from_f64(rng.r#gen()).unwrap()),
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ValueFaker, rng: &mut R) -> Self {
+        CustomValue(match rng.random_range(0..=5) {
+            1 => Value::Bool(rng.random()),
+            2 => Value::Number(serde_json::Number::from_f64(rng.random()).unwrap()),
             3 => Value::String(Faker.fake::<String>()),
             _ => Value::Null,
         })

--- a/docs/external/src/debugging-programmatically.md
+++ b/docs/external/src/debugging-programmatically.md
@@ -105,7 +105,7 @@ use miden_debug::{Executor, BreakpointType};
 
 let source_manager = Arc::new(DefaultSourceManager::default());
 let program_package = Package::deserialize_from_file("path/to/program.masp").map(Arc::new).unwrap();
-let exec = Executor::for_package(program_package.clone(), args).unwrap();
+let exec = Executor::for_package(&program_package, args).unwrap();
 
 let program = program_package.unwrap_program();
 let mut debug_exec = exec.into_debug(&program, source_manager.clone());
@@ -143,6 +143,39 @@ assert!(stack.len() <= 16);
 ```
 
 We will continue to expand on the set of useful APIs for examining program state in upcoming releases.
+
+## Generating flamegraphs programmatically
+
+The flamegraph support is also exposed as a Rust API, so tests can profile a
+program without shelling out to the `miden-debug flamegraph` command. Enable the
+`flamegraph` feature on `miden-debug`, execute a program with a `DebugExecutor`,
+and collect a `FlamegraphProfile` from it:
+
+```rust
+use std::sync::Arc;
+use miden_debug::{
+    Executor,
+    debug_types::DefaultSourceManager,
+    flamegraph::FlamegraphProfile,
+};
+
+let source_manager = Arc::new(DefaultSourceManager::default());
+let program_package = Package::deserialize_from_file("path/to/program.masp").map(Arc::new).unwrap();
+let exec = Executor::for_package(&program_package, args).unwrap();
+
+let program = program_package.unwrap_program();
+let mut debug_exec = exec.into_debug(&program, source_manager);
+
+let profile = FlamegraphProfile::collect(&mut debug_exec).expect("program execution failed");
+assert!(profile.total_cycles() > 0);
+
+profile.write_svg("target/miden-flamegraph.svg").expect("failed to write flamegraph");
+```
+
+If you are integrating with another executor, you can also build a profile from
+already resolved stack names by calling `FlamegraphProfile::record_stack` or
+`FlamegraphProfile::record_stack_path`, then write the result as either SVG or
+folded stack text.
 
 ## Wrapping up
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,7 @@ use crate::{exec::ExecutionConfig, felt::Felt, input::InputFile, linker::LinkLib
 
 /// Run a compiled Miden program with the Miden VM
 #[derive(Default, Debug)]
-#[cfg_attr(any(feature = "tui", feature = "repl"), derive(clap::Parser))]
-#[cfg_attr(any(feature = "tui", feature = "repl"), command(author, version, about = "The interactive Miden debugger", long_about = None))]
+#[cfg_attr(any(feature = "tui", feature = "repl"), derive(clap::Args))]
 pub struct DebuggerConfig {
     /// Specify the path to a Miden program file to execute.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,21 +8,30 @@ use crate::{exec::ExecutionConfig, felt::Felt, input::InputFile, linker::LinkLib
 
 /// Run a compiled Miden program with the Miden VM
 #[derive(Default, Debug)]
-#[cfg_attr(any(feature = "tui", feature = "repl"), derive(clap::Args))]
+#[cfg_attr(
+    any(feature = "tui", feature = "repl", feature = "flamegraph"),
+    derive(clap::Args)
+)]
 pub struct DebuggerConfig {
     /// Specify the path to a Miden program file to execute.
     ///
     /// Miden Assembly programs are emitted by the compiler with a `.masp` extension.
     ///
     /// You may use `-` as a file name to read a file from stdin.
-    #[cfg_attr(any(feature = "tui", feature = "repl"), arg(value_name = "FILE"))]
+    #[cfg_attr(
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
+        arg(value_name = "FILE")
+    )]
     pub input: Option<InputFile>,
     /// Specify the path to a file containing program inputs.
     ///
     /// Program inputs are stack and advice provider values which the program can
     /// access during execution. The inputs file is a TOML file which describes
     /// what the inputs are, or where to source them from.
-    #[cfg_attr(any(feature = "tui", feature = "repl"), arg(long, value_name = "FILE"))]
+    #[cfg_attr(
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
+        arg(long, value_name = "FILE")
+    )]
     pub inputs: Option<ExecutionConfig>,
     /// Arguments to place on the operand stack before calling the program entrypoint.
     ///
@@ -34,7 +43,7 @@ pub struct DebuggerConfig {
     ///
     /// NOTE: These arguments will override any stack values provided via --inputs
     #[cfg_attr(
-        any(feature = "tui", feature = "repl"),
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
         arg(last(true), value_name = "ARGV")
     )]
     pub args: Vec<Felt>,
@@ -42,7 +51,7 @@ pub struct DebuggerConfig {
     ///
     /// By default this will be the working directory the debugger is executed from
     #[cfg_attr(
-        feature = "tui",
+        any(feature = "tui", feature = "flamegraph"),
         arg(long, value_name = "DIR", help_heading = "Execution")
     )]
     pub working_dir: Option<PathBuf>,
@@ -50,7 +59,7 @@ pub struct DebuggerConfig {
     ///
     /// By default this is assumed to be `$(midenup show home)/toolchains/$(midenup show active-toolchain)
     #[cfg_attr(
-        feature = "tui",
+        any(feature = "tui", feature = "flamegraph"),
         arg(
             long,
             value_name = "DIR",
@@ -60,7 +69,7 @@ pub struct DebuggerConfig {
     )]
     pub sysroot: Option<PathBuf>,
     /// Whether, and how, to color terminal output
-    #[cfg_attr(any(feature = "tui", feature = "repl"), arg(
+    #[cfg_attr(any(feature = "tui", feature = "repl", feature = "flamegraph"), arg(
         long,
         value_enum,
         default_value_t = ColorChoice::Auto,
@@ -72,7 +81,7 @@ pub struct DebuggerConfig {
     /// Specify the function to call as the entrypoint for the program
     /// in the format `<module_name>::<function>`
     #[cfg_attr(
-        any(feature = "tui", feature = "repl"),
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
         arg(long, help_heading = "Execution")
     )]
     pub entrypoint: Option<String>,
@@ -82,13 +91,13 @@ pub struct DebuggerConfig {
     /// When this flag is set, the debugger connects to an existing remote session.
     #[cfg(feature = "dap")]
     #[cfg_attr(
-        feature = "tui",
+        any(feature = "tui", feature = "flamegraph"),
         arg(long, value_name = "ADDR", help_heading = "Execution")
     )]
     pub dap_connect: Option<String>,
     /// Specify one or more search paths for link libraries requested via `-l`
     #[cfg_attr(
-        feature = "tui",
+        any(feature = "tui", feature = "flamegraph"),
         arg(
             long = "search-path",
             short = 'L',
@@ -108,7 +117,7 @@ pub struct DebuggerConfig {
     ///
     /// See below for valid KINDs:
     #[cfg_attr(
-        feature = "tui",
+        any(feature = "tui", feature = "flamegraph"),
         arg(
             long = "link-library",
             short = 'l',
@@ -121,7 +130,7 @@ pub struct DebuggerConfig {
     pub link_libraries: Vec<LinkLibrary>,
     /// Use the REPL (text-mode) debugger instead of the TUI
     #[cfg_attr(
-        any(feature = "tui", feature = "repl"),
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
         arg(long, help_heading = "Output")
     )]
     pub repl: bool,
@@ -136,7 +145,10 @@ pub struct DebuggerConfig {
 /// string of the variant name to the corresponding variant. Any other string
 /// results in an error.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "tui", feature = "repl"), derive(clap::ValueEnum))]
+#[cfg_attr(
+    any(feature = "tui", feature = "repl", feature = "flamegraph"),
+    derive(clap::ValueEnum)
+)]
 pub enum ColorChoice {
     /// Try very hard to emit colors. This includes emitting ANSI colors
     /// on Windows if the console API is unavailable.

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -1,0 +1,342 @@
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use miden_assembly::{DefaultSourceManager, SourceManager};
+use miden_assembly_syntax::{
+    Library,
+    diagnostics::{IntoDiagnostic, Report, WrapErr},
+};
+use miden_core::serde::Deserializable;
+use miden_processor::StackInputs;
+
+use crate::{
+    config::{ColorChoice, DebuggerConfig},
+    debug::CallFrame,
+    exec::{ExecutionConfig, Executor},
+    felt::Felt,
+    input::InputFile,
+    linker::LinkLibrary,
+};
+
+type Samples = BTreeMap<String, usize>;
+
+#[derive(clap::Args, Debug)]
+pub struct FlamegraphArgs {
+    /// Specify the path to a Miden program file to execute.
+    #[arg(value_name = "FILE")]
+    pub input: InputFile,
+
+    /// Write the generated flame graph SVG or folded stack text to this path.
+    #[arg(short, long, default_value = "flamegraph.svg")]
+    pub output: PathBuf,
+
+    /// Specify the path to a file containing program inputs.
+    #[arg(long, value_name = "FILE")]
+    pub inputs: Option<ExecutionConfig>,
+
+    /// Arguments to place on the operand stack before calling the program entrypoint.
+    #[arg(last(true), value_name = "ARGV")]
+    pub args: Vec<Felt>,
+
+    /// The working directory for execution.
+    #[arg(long, value_name = "DIR", help_heading = "Execution")]
+    pub working_dir: Option<PathBuf>,
+
+    /// The path to the root directory of the current Miden toolchain.
+    #[arg(
+        long,
+        value_name = "DIR",
+        env = "MIDEN_SYSROOT",
+        help_heading = "Linker"
+    )]
+    pub sysroot: Option<PathBuf>,
+
+    /// Specify the function to call as the entrypoint for the program.
+    #[arg(long, help_heading = "Execution")]
+    pub entrypoint: Option<String>,
+
+    /// Specify one or more search paths for link libraries requested via `-l`.
+    #[arg(
+        long = "search-path",
+        short = 'L',
+        value_name = "PATH",
+        help_heading = "Linker"
+    )]
+    pub search_path: Vec<PathBuf>,
+
+    /// Link compiled projects to the specified library NAME.
+    #[arg(
+        long = "link-library",
+        short = 'l',
+        value_name = "[KIND=]NAME",
+        value_delimiter = ',',
+        next_line_help(true),
+        help_heading = "Linker"
+    )]
+    pub link_libraries: Vec<LinkLibrary>,
+}
+
+impl FlamegraphArgs {
+    fn into_debugger_config(self) -> DebuggerConfig {
+        DebuggerConfig {
+            input: Some(self.input),
+            inputs: self.inputs,
+            args: self.args,
+            working_dir: self.working_dir,
+            sysroot: self.sysroot,
+            color: ColorChoice::Auto,
+            entrypoint: self.entrypoint,
+            #[cfg(feature = "dap")]
+            dap_connect: None,
+            search_path: self.search_path,
+            link_libraries: self.link_libraries,
+            repl: false,
+        }
+    }
+}
+
+pub fn run(args: FlamegraphArgs) -> Result<(), Report> {
+    let output = args.output.clone();
+    let mut config = args.into_debugger_config();
+    ensure_working_dir(&mut config)?;
+
+    let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+    let mut inputs = execution_inputs(&config)?;
+    let args = inputs.inputs.iter().copied().collect::<Vec<_>>();
+    let package = load_package(&config)?;
+
+    let libs = load_libraries(&config, source_manager.clone())?;
+
+    let mut executor = Executor::new(args);
+    for lib in libs.iter() {
+        executor.register_library_dependency(lib.clone());
+        executor.with_library(lib.clone());
+    }
+    executor.with_dependencies(package.manifest.dependencies())?;
+    executor.with_advice_inputs(core::mem::take(&mut inputs.advice_inputs));
+
+    let program = package.unwrap_program();
+    let mut executor = executor.into_debug(&program, source_manager);
+
+    let mut samples = Samples::default();
+    let mut total_cycles = 0usize;
+
+    loop {
+        if executor.stopped {
+            break;
+        }
+
+        let previous_cycle = executor.cycle;
+        match executor.step() {
+            Ok(_) if executor.cycle > previous_cycle => {
+                let cycle_delta = executor.cycle - previous_cycle;
+                total_cycles += cycle_delta;
+                let path = build_stack_path(executor.callstack.frames());
+                *samples.entry(path).or_default() += cycle_delta;
+            }
+            Ok(_) => {
+                if executor.stopped {
+                    break;
+                }
+            }
+            Err(err) => {
+                return Err(Report::msg(format!(
+                    "program execution failed at cycle {}: {err}",
+                    executor.cycle
+                )));
+            }
+        }
+    }
+
+    eprintln!("Executed {total_cycles} cycles across {} unique stack paths", samples.len());
+
+    if is_svg_path(&output) {
+        generate_svg(&samples, &output)?;
+    } else {
+        write_folded_stacks(&samples, &output)?;
+    }
+
+    Ok(())
+}
+
+fn ensure_working_dir(config: &mut DebuggerConfig) -> Result<(), Report> {
+    if config.working_dir.is_none() {
+        let cwd = std::env::current_dir()
+            .into_diagnostic()
+            .wrap_err("could not read current working directory")?;
+        config.working_dir = Some(cwd);
+    }
+
+    Ok(())
+}
+
+fn execution_inputs(config: &DebuggerConfig) -> Result<ExecutionConfig, Report> {
+    let mut inputs = config.inputs.clone().unwrap_or_default();
+    if !config.args.is_empty() {
+        // CLI args model sequential pushes, but StackInputs expects the top element first.
+        let args = config.args.iter().rev().map(|felt| felt.0).collect::<Vec<_>>();
+        inputs.inputs = StackInputs::new(&args).into_diagnostic()?;
+    }
+
+    Ok(inputs)
+}
+
+fn load_libraries(
+    config: &DebuggerConfig,
+    source_manager: Arc<dyn SourceManager>,
+) -> Result<Vec<Arc<Library>>, Report> {
+    let mut libs = Vec::with_capacity(config.link_libraries.len());
+    for link_library in config.link_libraries.iter() {
+        log::debug!(target: "flamegraph", "loading link library {}", link_library.name());
+        libs.push(link_library.load(config, source_manager.clone())?);
+    }
+
+    if let Some(toolchain_dir) = config.toolchain_dir() {
+        libs.extend(load_sysroot_libs(&toolchain_dir)?);
+    }
+
+    Ok(libs)
+}
+
+fn load_sysroot_libs(toolchain_dir: &Path) -> Result<Vec<Arc<Library>>, Report> {
+    let mut libs = Vec::new();
+
+    let entries = match std::fs::read_dir(toolchain_dir) {
+        Ok(entries) => entries,
+        Err(_) => {
+            log::debug!(target: "flamegraph", "could not read sysroot directory: {}", toolchain_dir.display());
+            return Ok(libs);
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.into_diagnostic()?;
+        let path = entry.path();
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+
+        if ext == "masp" {
+            log::debug!(target: "flamegraph", "loading library from sysroot: {}", path.display());
+            let bytes = std::fs::read(&path).into_diagnostic()?;
+            let package = miden_mast_package::Package::read_from_bytes(&bytes).map_err(|e| {
+                Report::msg(format!("failed to load package '{}': {e}", path.display()))
+            })?;
+            libs.push(package.mast.clone());
+        } else if ext == "masl" {
+            log::debug!(target: "flamegraph", "loading library from sysroot: {}", path.display());
+            let bytes = std::fs::read(&path).into_diagnostic()?;
+            let lib = Library::read_from_bytes(&bytes).map_err(|e| {
+                Report::msg(format!("failed to load library '{}': {e}", path.display()))
+            })?;
+            libs.push(Arc::new(lib));
+        }
+    }
+
+    Ok(libs)
+}
+
+fn load_package(config: &DebuggerConfig) -> Result<Arc<miden_mast_package::Package>, Report> {
+    let input = config.input.as_ref().ok_or_else(|| Report::msg("no input file specified"))?;
+    let package = match input {
+        InputFile::Real(path) => {
+            let bytes = std::fs::read(path).into_diagnostic()?;
+            miden_mast_package::Package::read_from_bytes(&bytes)
+                .map(Arc::new)
+                .map_err(|e| {
+                    Report::msg(format!(
+                        "failed to load Miden package from {}: {e}",
+                        path.display()
+                    ))
+                })?
+        }
+        InputFile::Stdin(bytes) => miden_mast_package::Package::read_from_bytes(bytes)
+            .map(Arc::new)
+            .map_err(|e| Report::msg(format!("failed to load Miden package from stdin: {e}")))?,
+    };
+
+    if let Some(entry) = config.entrypoint.as_ref() {
+        let id = entry
+            .parse::<miden_assembly::ast::QualifiedProcedureName>()
+            .map_err(|_| Report::msg(format!("invalid function identifier: '{entry}'")))?;
+        if !package.is_library() {
+            return Err(Report::msg("cannot use --entrypoint with executable packages"));
+        }
+
+        package.make_executable(&id).map(Arc::new)
+    } else {
+        Ok(package)
+    }
+}
+
+fn build_stack_path(frames: &[CallFrame]) -> String {
+    let mut path = String::new();
+    for frame in frames {
+        let Some(name) = frame.procedure("") else {
+            continue;
+        };
+        if !path.is_empty() {
+            path.push(';');
+        }
+        append_sanitized_frame(&mut path, &name);
+    }
+
+    if path.is_empty() {
+        "[unknown]".to_string()
+    } else {
+        path
+    }
+}
+
+fn append_sanitized_frame(path: &mut String, name: &str) {
+    for ch in name.chars() {
+        match ch {
+            ';' => path.push(':'),
+            '\n' | '\r' => path.push(' '),
+            _ => path.push(ch),
+        }
+    }
+}
+
+fn is_svg_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+}
+
+fn write_folded_stacks(samples: &Samples, path: &Path) -> Result<(), Report> {
+    let file = File::create(path).into_diagnostic()?;
+    let mut writer = BufWriter::new(file);
+    for (stack, count) in samples {
+        writeln!(writer, "{stack} {count}").into_diagnostic()?;
+    }
+    writer.flush().into_diagnostic()?;
+
+    eprintln!("Wrote folded stacks to {}", path.display());
+    Ok(())
+}
+
+fn generate_svg(samples: &Samples, path: &Path) -> Result<(), Report> {
+    let input = samples
+        .iter()
+        .map(|(stack, count)| format!("{stack} {count}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut opts = inferno::flamegraph::Options::default();
+    opts.title = "Miden VM Flame Graph (cycles)".to_string();
+    opts.count_name = "cycles".to_string();
+
+    let file = File::create(path).into_diagnostic()?;
+    let mut writer = BufWriter::new(file);
+    inferno::flamegraph::from_reader(&mut opts, input.as_bytes(), &mut writer).into_diagnostic()?;
+    writer.flush().into_diagnostic()?;
+
+    eprintln!("Wrote flame graph to {}", path.display());
+    Ok(())
+}

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -12,18 +12,124 @@ use miden_assembly_syntax::{
     diagnostics::{IntoDiagnostic, Report, WrapErr},
 };
 use miden_core::serde::Deserializable;
-use miden_processor::StackInputs;
+use miden_processor::{ExecutionError, StackInputs};
 
 use crate::{
     config::{ColorChoice, DebuggerConfig},
     debug::CallFrame,
-    exec::{ExecutionConfig, Executor},
+    exec::{DebugExecutor, ExecutionConfig, Executor},
     felt::Felt,
     input::InputFile,
     linker::LinkLibrary,
 };
 
-type Samples = BTreeMap<String, usize>;
+/// Folded stack samples keyed by semicolon-separated stack paths.
+pub type Samples = BTreeMap<String, usize>;
+
+/// A collected VM cycle profile that can be rendered as folded stacks or an SVG flamegraph.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FlamegraphProfile {
+    samples: Samples,
+    total_cycles: usize,
+}
+
+/// The output format selected by [`FlamegraphProfile::write_to_path`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FlamegraphOutput {
+    Svg,
+    FoldedStacks,
+}
+
+impl FlamegraphProfile {
+    /// Execute `executor` to completion, sampling its call stack for every VM cycle.
+    pub fn collect(executor: &mut DebugExecutor) -> Result<Self, ExecutionError> {
+        let mut profile = Self::default();
+
+        loop {
+            if executor.stopped {
+                break;
+            }
+
+            let previous_cycle = executor.cycle;
+            match executor.step() {
+                Ok(_) if executor.cycle > previous_cycle => {
+                    let cycle_delta = executor.cycle - previous_cycle;
+                    profile.record_call_stack(executor.callstack.frames(), cycle_delta);
+                }
+                Ok(_) => {
+                    if executor.stopped {
+                        break;
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(profile)
+    }
+
+    /// Record `cycles` against a call stack from the debugger engine.
+    pub fn record_call_stack(&mut self, frames: &[CallFrame], cycles: usize) {
+        let path = build_stack_path(frames);
+        self.record_stack_path(path, cycles);
+    }
+
+    /// Record `cycles` against a stack of frame names.
+    ///
+    /// Frame names are sanitized for folded stack output, then joined with `;`.
+    pub fn record_stack<I, S>(&mut self, frames: I, cycles: usize)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let path = build_stack_path_from_names(frames);
+        self.record_stack_path(path, cycles);
+    }
+
+    /// Record `cycles` against an already formatted folded-stack path.
+    pub fn record_stack_path(&mut self, stack_path: impl Into<String>, cycles: usize) {
+        if cycles == 0 {
+            return;
+        }
+
+        self.total_cycles += cycles;
+        *self.samples.entry(stack_path.into()).or_default() += cycles;
+    }
+
+    pub fn samples(&self) -> &Samples {
+        &self.samples
+    }
+
+    pub fn total_cycles(&self) -> usize {
+        self.total_cycles
+    }
+
+    pub fn unique_stack_paths(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Write this profile as an SVG when `path` ends in `.svg`, otherwise as folded stack text.
+    pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<FlamegraphOutput, Report> {
+        let path = path.as_ref();
+        if is_svg_path(path) {
+            self.write_svg(path)?;
+            Ok(FlamegraphOutput::Svg)
+        } else {
+            self.write_folded_stacks(path)?;
+            Ok(FlamegraphOutput::FoldedStacks)
+        }
+    }
+
+    /// Write this profile in folded stack format.
+    pub fn write_folded_stacks(&self, path: impl AsRef<Path>) -> Result<(), Report> {
+        write_folded_stacks(&self.samples, path.as_ref())
+    }
+
+    /// Render this profile as an SVG flamegraph.
+    pub fn write_svg(&self, path: impl AsRef<Path>) -> Result<(), Report> {
+        generate_svg(&self.samples, path.as_ref())
+    }
+}
 
 #[derive(clap::Args, Debug)]
 pub struct FlamegraphArgs {
@@ -123,43 +229,23 @@ pub fn run(args: FlamegraphArgs) -> Result<(), Report> {
     let program = package.unwrap_program();
     let mut executor = executor.into_debug(&program, source_manager);
 
-    let mut samples = Samples::default();
-    let mut total_cycles = 0usize;
-
-    loop {
-        if executor.stopped {
-            break;
+    let profile = match FlamegraphProfile::collect(&mut executor) {
+        Ok(profile) => profile,
+        Err(err) => {
+            return Err(Report::msg(format!(
+                "program execution failed at cycle {}: {err}",
+                executor.cycle
+            )));
         }
+    };
 
-        let previous_cycle = executor.cycle;
-        match executor.step() {
-            Ok(_) if executor.cycle > previous_cycle => {
-                let cycle_delta = executor.cycle - previous_cycle;
-                total_cycles += cycle_delta;
-                let path = build_stack_path(executor.callstack.frames());
-                *samples.entry(path).or_default() += cycle_delta;
-            }
-            Ok(_) => {
-                if executor.stopped {
-                    break;
-                }
-            }
-            Err(err) => {
-                return Err(Report::msg(format!(
-                    "program execution failed at cycle {}: {err}",
-                    executor.cycle
-                )));
-            }
-        }
-    }
+    eprintln!(
+        "Executed {} cycles across {} unique stack paths",
+        profile.total_cycles(),
+        profile.unique_stack_paths()
+    );
 
-    eprintln!("Executed {total_cycles} cycles across {} unique stack paths", samples.len());
-
-    if is_svg_path(&output) {
-        generate_svg(&samples, &output)?;
-    } else {
-        write_folded_stacks(&samples, &output)?;
-    }
+    profile.write_to_path(&output)?;
 
     Ok(())
 }
@@ -275,15 +361,17 @@ fn load_package(config: &DebuggerConfig) -> Result<Arc<miden_mast_package::Packa
 }
 
 fn build_stack_path(frames: &[CallFrame]) -> String {
+    build_stack_path_from_names(frames.iter().filter_map(|frame| frame.procedure("")))
+}
+
+fn build_stack_path_from_names<I, S>(frames: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
     let mut path = String::new();
     for frame in frames {
-        let Some(name) = frame.procedure("") else {
-            continue;
-        };
-        if !path.is_empty() {
-            path.push(';');
-        }
-        append_sanitized_frame(&mut path, &name);
+        append_frame(&mut path, frame.as_ref());
     }
 
     if path.is_empty() {
@@ -291,6 +379,13 @@ fn build_stack_path(frames: &[CallFrame]) -> String {
     } else {
         path
     }
+}
+
+fn append_frame(path: &mut String, name: &str) {
+    if !path.is_empty() {
+        path.push(';');
+    }
+    append_sanitized_frame(path, name);
 }
 
 fn append_sanitized_frame(path: &mut String, name: &str) {
@@ -339,4 +434,23 @@ fn generate_svg(samples: &Samples, path: &Path) -> Result<(), Report> {
 
     eprintln!("Wrote flame graph to {}", path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlamegraphProfile;
+
+    #[test]
+    fn record_stack_sanitizes_folded_stack_frames() {
+        let mut profile = FlamegraphProfile::default();
+
+        profile.record_stack(["root;proc", "child\nproc"], 3);
+        profile.record_stack(["root;proc", "child\nproc"], 2);
+        profile.record_stack(["ignored"], 0);
+
+        assert_eq!(profile.total_cycles(), 5);
+        assert_eq!(profile.unique_stack_paths(), 1);
+        assert_eq!(profile.samples().get("root:proc;child proc"), Some(&5));
+        assert!(!profile.samples().contains_key("ignored"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub use miden_debug_engine::{debug, debug_types, events, exec, felt, processor};
 
 mod config;
+#[cfg(feature = "tui")]
+pub mod flamegraph;
 mod input;
 mod linker;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub use miden_debug_engine::{debug, debug_types, events, exec, felt, processor};
 
 mod config;
-#[cfg(feature = "tui")]
+#[cfg(feature = "flamegraph")]
 pub mod flamegraph;
 mod input;
 mod linker;

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -175,7 +175,7 @@ impl LinkLibrary {
     }
 }
 
-#[cfg(feature = "tui")]
+#[cfg(any(feature = "tui", feature = "flamegraph"))]
 impl clap::builder::ValueParserFactory for LinkLibrary {
     type Parser = LinkLibraryParser;
 
@@ -184,12 +184,12 @@ impl clap::builder::ValueParserFactory for LinkLibrary {
     }
 }
 
-#[cfg(feature = "tui")]
+#[cfg(any(feature = "tui", feature = "flamegraph"))]
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct LinkLibraryParser;
 
-#[cfg(feature = "tui")]
+#[cfg(any(feature = "tui", feature = "flamegraph"))]
 impl clap::builder::TypedValueParser for LinkLibraryParser {
     type Value = LinkLibrary;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use std::env;
 
 use clap::Parser;
-#[cfg(feature = "tui")]
+#[cfg(feature = "flamegraph")]
 use clap::Subcommand;
 use miden_assembly_syntax::diagnostics::{IntoDiagnostic, Report, WrapErr};
 use miden_debug::DebuggerConfig;
-#[cfg(feature = "tui")]
+#[cfg(feature = "flamegraph")]
 use miden_debug::flamegraph::FlamegraphArgs;
 #[cfg(feature = "repl")]
 use miden_debug::run_repl_with_log_level as run_repl;
@@ -18,7 +18,7 @@ use miden_debug::{State, run_with_state_and_log_level as run_with_state};
 #[command(author, version, about = "The interactive Miden debugger")]
 #[command(args_conflicts_with_subcommands = true)]
 struct Cli {
-    #[cfg(feature = "tui")]
+    #[cfg(feature = "flamegraph")]
     #[command(subcommand)]
     command: Option<Commands>,
 
@@ -26,7 +26,7 @@ struct Cli {
     config: DebuggerConfig,
 }
 
-#[cfg(feature = "tui")]
+#[cfg(feature = "flamegraph")]
 #[derive(Subcommand)]
 enum Commands {
     /// Generate a flame graph SVG from program execution cycle counts
@@ -61,7 +61,7 @@ pub fn main() -> Result<(), Report> {
     let logger = Box::new(logger);
     let cli = Cli::parse();
 
-    #[cfg(feature = "tui")]
+    #[cfg(feature = "flamegraph")]
     if let Some(command) = cli.command {
         return match command {
             Commands::Flamegraph(args) => {
@@ -78,8 +78,8 @@ pub fn main() -> Result<(), Report> {
 
 fn run_debugger(
     mut config: Box<DebuggerConfig>,
-    logger: Box<dyn log::Log>,
-    log_level: log::LevelFilter,
+    _logger: Box<dyn log::Log>,
+    _log_level: log::LevelFilter,
 ) -> Result<(), Report> {
     if config.working_dir.is_none() {
         let cwd = env::current_dir()
@@ -92,16 +92,16 @@ fn run_debugger(
     #[cfg(feature = "dap")]
     if let Some(addr) = config.dap_connect.as_ref() {
         let state = State::new_for_dap(addr)?;
-        return run_with_state(state, logger, log_level);
+        return run_with_state(state, _logger, _log_level);
     }
 
     #[cfg(feature = "repl")]
     if config.repl {
-        return run_repl(config, logger, log_level);
+        return run_repl(config, _logger, _log_level);
     }
 
     #[cfg(feature = "tui")]
-    return run(config, logger, log_level);
+    return run(config, _logger, _log_level);
 
     #[cfg(not(feature = "tui"))]
     Err(Report::msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,37 @@
 use std::env;
 
 use clap::Parser;
+#[cfg(feature = "tui")]
+use clap::Subcommand;
 use miden_assembly_syntax::diagnostics::{IntoDiagnostic, Report, WrapErr};
 use miden_debug::DebuggerConfig;
+#[cfg(feature = "tui")]
+use miden_debug::flamegraph::FlamegraphArgs;
 #[cfg(feature = "repl")]
 use miden_debug::run_repl_with_log_level as run_repl;
 #[cfg(feature = "tui")]
 use miden_debug::run_with_log_level as run;
 #[cfg(feature = "dap")]
 use miden_debug::{State, run_with_state_and_log_level as run_with_state};
+
+#[derive(Parser)]
+#[command(author, version, about = "The interactive Miden debugger")]
+#[command(args_conflicts_with_subcommands = true)]
+struct Cli {
+    #[cfg(feature = "tui")]
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    config: DebuggerConfig,
+}
+
+#[cfg(feature = "tui")]
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate a flame graph SVG from program execution cycle counts
+    Flamegraph(FlamegraphArgs),
+}
 
 pub fn main() -> Result<(), Report> {
     setup_diagnostics();
@@ -36,8 +59,28 @@ pub fn main() -> Result<(), Report> {
     let logger = builder.build();
     let log_level = logger.filter();
     let logger = Box::new(logger);
-    let mut config = Box::new(DebuggerConfig::parse());
+    let cli = Cli::parse();
 
+    #[cfg(feature = "tui")]
+    if let Some(command) = cli.command {
+        return match command {
+            Commands::Flamegraph(args) => {
+                log::set_boxed_logger(logger)
+                    .map_err(|err| Report::msg(format!("failed to install logger: {err}")))?;
+                log::set_max_level(log_level);
+                miden_debug::flamegraph::run(args)
+            }
+        };
+    }
+
+    run_debugger(Box::new(cli.config), logger, log_level)
+}
+
+fn run_debugger(
+    mut config: Box<DebuggerConfig>,
+    logger: Box<dyn log::Log>,
+    log_level: log::LevelFilter,
+) -> Result<(), Report> {
     if config.working_dir.is_none() {
         let cwd = env::current_dir()
             .into_diagnostic()

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -543,8 +543,7 @@ fn format_bp_type(ty: &BreakpointType) -> String {
         BreakpointType::Finish => "function return".into(),
         BreakpointType::File(pat) => pat.as_str().to_string(),
         BreakpointType::Line { pattern, line } => format!("{}:{}", pattern.as_str(), line),
-        BreakpointType::Opcode(op) => format!("opcode {:?}", op),
-        BreakpointType::AsmOpcode(name) => format!("asm opcode {name}"),
+        BreakpointType::Opcode(matcher) => format!("opcode {matcher}"),
         BreakpointType::Called(pat) => format!("call {}", pat.as_str()),
         BreakpointType::Trace(event) => format!("trace event {event:?}"),
     }

--- a/tests/flamegraph_profile.rs
+++ b/tests/flamegraph_profile.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use miden_assembly::{Assembler, DefaultSourceManager, SourceManager};
+use miden_debug::{Executor, flamegraph::FlamegraphProfile};
+
+#[test]
+fn flamegraph_profile_can_be_collected_from_debug_executor() {
+    let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+    let source = r#"
+begin
+    push.1
+    push.2
+    add
+    push.10
+    mul
+    swap
+    drop
+end
+"#;
+
+    let program = Assembler::new(source_manager.clone()).assemble_program(source).unwrap();
+    let mut debug_executor = Executor::new(vec![]).into_debug(&program, source_manager);
+
+    let profile =
+        FlamegraphProfile::collect(&mut debug_executor).expect("program execution failed");
+
+    assert!(debug_executor.stopped);
+    assert!(profile.total_cycles() > 0);
+    assert!(!profile.samples().is_empty());
+    assert_eq!(profile.samples().values().sum::<usize>(), profile.total_cycles());
+}


### PR DESCRIPTION
Implemented `miden-debug flamegraph` as a non-interactive execution mode. It drives `DebugExecutor` to completion one VM cycle at a time, samples `callstack.frames()` on each cycle, converts frames to semicolon-separated folded stack paths, aggregates cycle counts per stack, and renders the result as an SVG flame graph with inferno or as folded-stack text for external tools

It uses `inferno` crate as a new dependency.