### PR TITLE
chore: bump miden-vm to 0.23 / miden-crypto to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug"
-version = "0.8.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "compact_str",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-dap"
-version = "0.8.0"
+version = "0.7.1"
 dependencies = [
  "fake",
  "rand 0.10.1",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-engine"
-version = "0.8.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,13 +1540,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-air"
-version = "0.22.3"
+name = "miden-ace-codegen"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d25e77d4f3ff87ef8fad40a5d960b376052ead4b320dce3e1d25e9ff7f8d94d"
+checksum = "1c5e3d08008b5f9dd3e6145e55e4d3c1a4e47a74383dd8d0d64003455ee94510"
 dependencies = [
  "miden-core",
  "miden-crypto",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-air"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d980fa23010e53c43077cf0182e6e88acd1a099abbf8a98cd298aa69b86688dc"
+dependencies = [
+ "miden-ace-codegen",
+ "miden-core",
+ "miden-crypto",
+ "miden-lifted-stark",
  "miden-utils-indexing",
  "thiserror 2.0.18",
  "tracing",
@@ -1548,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68646887a71f296dc4ada04339cab404fabd64c4cc2c0ffcb4cbac875cbf48f"
+checksum = "24eb53abd723b7dd8ff1210b7d126f0d9e1d9127ea0e7f6a46471845d060cc43"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1563,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc18089c8198135843019dc6d8686031a3946f5839ea1c3ba626b5eb7fdf09c7"
+checksum = "02ead435c8dccfd3b9bd97779cfa0d74cc14c767a9740f162bf7cd49a0da26bd"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1586,12 +1605,12 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778063e712a9000e177ac3f3ac5f9cd7cfc15f4670124127c182495ef8667dd3"
+checksum = "9a7c7eecda385bcc66aea99ee3279ae7c78f38e3541f4c1d67d309ac32314ff4"
 dependencies = [
  "derive_more",
- "itertools",
+ "log",
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
@@ -1606,24 +1625,26 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
+checksum = "72ae084a6d15d5d862760bcbdbb5caad41415ed455cd7ab2b53a012d21a431ed"
 dependencies = [
  "blake3",
  "cc",
  "chacha20poly1305",
  "curve25519-dalek",
+ "der",
  "ed25519-dalek",
  "flume",
- "glob",
  "hkdf",
  "k256",
  "miden-crypto-derive",
  "miden-field",
+ "miden-lifted-stark",
  "miden-serde-utils",
  "num",
  "num-complex",
+ "once_cell",
  "p3-blake3",
  "p3-challenger",
  "p3-dft",
@@ -1631,7 +1652,6 @@ dependencies = [
  "p3-keccak",
  "p3-matrix",
  "p3-maybe-rayon",
- "p3-miden-lifted-stark",
  "p3-symmetric",
  "p3-util",
  "rand 0.9.4",
@@ -1648,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
+checksum = "e8523f6ac9b28782ca759920e536164e7eab7dbfaf9132721ca3e325c060df73"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1658,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "clap",
  "compact_str",
@@ -1685,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-dap"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "fake",
  "rand 0.10.1",
@@ -1696,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-engine"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "clap",
  "glob",
@@ -1721,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be29c7988811012c28526550af39f98f5b5a26aca5c8629906fef4fc49c8180"
+checksum = "206f5346bef744da1ffae9874a22170a2d0c27dd20947d89182d16f5d86348f7"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1732,6 +1752,7 @@ dependencies = [
  "miden-utils-indexing",
  "miden-utils-sync",
  "paste",
+ "proptest",
  "serde",
  "serde_spanned",
  "thiserror 2.0.18",
@@ -1739,15 +1760,16 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+checksum = "7b8a48ba526c353bf583bba18ddf62ad4846945e85fcaf44614633276416b5d9"
 dependencies = [
  "miden-serde-utils",
  "num-bigint",
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
+ "p3-util",
  "paste",
  "rand 0.10.1",
  "serde",
@@ -1765,12 +1787,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-mast-package"
-version = "0.22.3"
+name = "miden-lifted-air"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dce38750178dba0fcc5c383c5daa5015a7cf235b6bfe12201184242e959a6aa"
+checksum = "a00d97ada3bfd70d6cc4f1a13ced8cb509f72fb16b1b28c292366aee846d3220"
 dependencies = [
- "derive_more",
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-lifted-stark"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3601a30d39e08a31ecc5b5215c87b11623942d9610aebccda89a4a5bf757c4"
+dependencies = [
+ "miden-lifted-air",
+ "miden-stark-transcript",
+ "miden-stateful-hasher",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-goldilocks",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "miden-mast-package"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae69cd4dc25b0993eb5fafcc99987abd3502d8a7a902248af4a597537dce600"
+dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
@@ -1816,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe834e5c0beffee4639b73ebb3348c391249c4a050e0b642f4efec67edcc88e"
+checksum = "8c1d77c6f5942f3111fc56a19d638076ea77df3628efa97c7955259c609ca8dd"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1829,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a32eca85a73122e0dfddd831de4d9fc678f718e5ef7f08dbfea233234f059"
+checksum = "70508a4a75989a47f03a0681df412b80040c76230c3d850f8f2b80f7a986d4aa"
 dependencies = [
  "itertools",
  "miden-air",
@@ -1842,15 +1899,14 @@ dependencies = [
  "paste",
  "rayon",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "miden-project"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c02a79e6ea81d806f40d42abaee696d2a54ad241eb563156964025e43bc54c"
+checksum = "6338d92713845f57b137e4305db11ee8614b0cec9b1516470233ce64d53f6376"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1864,19 +1920,41 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+checksum = "d899afcfbf85c851522f2dff73db1064116486fb8e0ebce0ade44ce72dadc075"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
 ]
 
 [[package]]
-name = "miden-utils-core-derive"
-version = "0.22.3"
+name = "miden-stark-transcript"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93293eea1811b5fdc6b3ca733b89c9e55b106fa61e99091e120e0fcb82d3a4b"
+checksum = "4c0e1f55bdff89f12ec6fc3881660a0d51d4e77f66026ab0e6ddcbd098a16f2f"
+dependencies = [
+ "p3-challenger",
+ "p3-field",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-stateful-hasher"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0069bab01139a5660c7189589c95dfedf8449514d03641fd3f9d049e1b031f9"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+]
+
+[[package]]
+name = "miden-utils-core-derive"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f74ef56bd44d23c805f662cd4f4639b04df6e0204d78806ede0e6f93d9695a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1885,33 +1963,33 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517f950c413485842842af2267f6d1c1cd5c9b7709169fc0accb1cb7ab9d2411"
+checksum = "c7b3aa61e0ee0f8a5b3f44250b73879437f9e10b6061c3ae743fd1cdb1f56321"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
  "miden-miette",
- "paste",
  "tracing",
 ]
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a930396e44160a6c0dbbdb71992a5d9bd0a777704200e49abcfe27ede8fb11"
+checksum = "57419a0557e580e04125542f4383910fb997660633e15ad4570ce1ff2ae80557"
 dependencies = [
  "miden-crypto",
+ "proptest",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc62908fccc609e2bc79dd66a1966fea88b1e256e53f64162a6ef19e087e362"
+checksum = "5a8a579c0c7cf44c123129045339f53b1f26f0aa2dc508494e97360d3ccab80e"
 dependencies = [
  "lock_api",
  "loom",
@@ -1921,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
+checksum = "1ff0511aa2201f7098995e38a3c97a319d379c3b2d26fb83677b21b71f61a7b4"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",
@@ -2134,6 +2212,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2218,19 +2300,6 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-commit"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
-dependencies = [
- "itertools",
- "p3-field",
- "p3-matrix",
- "p3-util",
- "serde",
 ]
 
 [[package]]
@@ -2327,102 +2396,6 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rand 0.10.1",
-]
-
-[[package]]
-name = "p3-miden-lifted-air"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
-dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-util",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "p3-miden-lifted-fri"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
-dependencies = [
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-lmcs",
- "p3-miden-transcript",
- "p3-util",
- "rand 0.10.1",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-lifted-stark"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
-dependencies = [
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-lifted-air",
- "p3-miden-lifted-fri",
- "p3-miden-lmcs",
- "p3-miden-stateful-hasher",
- "p3-miden-transcript",
- "p3-util",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-lmcs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
-dependencies = [
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-stateful-hasher",
- "p3-miden-transcript",
- "p3-symmetric",
- "p3-util",
- "rand 0.10.1",
- "serde",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-stateful-hasher"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
-dependencies = [
- "p3-field",
- "p3-symmetric",
-]
-
-[[package]]
-name = "p3-miden-transcript"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
-dependencies = [
- "p3-challenger",
- "p3-field",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/dap", "crates/engine"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.7.1"
 rust-version = "1.92"
 authors = ["Miden contributors"]
 repository = "https://github.com/0xMiden/miden-debug"
@@ -17,9 +17,9 @@ edition = "2024"
 
 [workspace.dependencies]
 clap = { version = "4.5", default-features = false, features = ["derive", "std", "env", "help", "suggestions", "error-context"]}
-dap = { package = "miden-debug-dap", version = "0.8.0", path = "crates/dap", features = ["client"] }
+dap = { package = "miden-debug-dap", version = "0.7.1", path = "crates/dap", features = ["client"] }
 log = "0.4"
-miden-debug-engine = { version = "0.8.0", path = "crates/engine", default-features = false }
+miden-debug-engine = { version = "0.7.1", path = "crates/engine", default-features = false }
 miden-assembly = { version = "0.23", default-features = false }
 miden-assembly-syntax = { version = "0.23", default-features = false }
 miden-core = { version = "0.23", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/dap", "crates/engine"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 rust-version = "1.92"
 authors = ["Miden contributors"]
 repository = "https://github.com/0xMiden/miden-debug"
@@ -17,15 +17,15 @@ edition = "2024"
 
 [workspace.dependencies]
 clap = { version = "4.5", default-features = false, features = ["derive", "std", "env", "help", "suggestions", "error-context"]}
-dap = { package = "miden-debug-dap", version = "0.7.1", path = "crates/dap", features = ["client"] }
+dap = { package = "miden-debug-dap", version = "0.8.0", path = "crates/dap", features = ["client"] }
 log = "0.4"
-miden-debug-engine = { version = "0.7.1", path = "crates/engine", default-features = false }
-miden-assembly = { version = "0.22", default-features = false }
-miden-assembly-syntax = { version = "0.22", default-features = false }
-miden-core = { version = "0.22", default-features = false }
-miden-debug-types = { version = "0.22", default-features = false }
-miden-mast-package = { version = "0.22", default-features = false }
-miden-processor = { version = "0.22", default-features = false }
+miden-debug-engine = { version = "0.8.0", path = "crates/engine", default-features = false }
+miden-assembly = { version = "0.23", default-features = false }
+miden-assembly-syntax = { version = "0.23", default-features = false }
+miden-core = { version = "0.23", default-features = false }
+miden-debug-types = { version = "0.23", default-features = false }
+miden-mast-package = { version = "0.23", default-features = false }
+miden-processor = { version = "0.23", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "serde_derive",
     "alloc",

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-debug-dap"
 description = "In-repo Debug Adapter Protocol support for miden-debug"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-debug-dap"
 description = "In-repo Debug Adapter Protocol support for miden-debug"
-version = "0.8.0"
+version = "0.7.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/dap/src/lib.rs
+++ b/crates/dap/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! Our dummy server is going to read its input from a text file and write the output to stdout.
 //!
-//! ```rust
+//! ```no_run
 //! use std::fs::File;
 //! use std::io::{BufReader, BufWriter};
 //!
@@ -62,9 +62,9 @@
 //!   };
 //!   if let Command::Initialize(_) = req.command {
 //!     let rsp = req.success(
-//!       ResponseBody::Initialize(Some(types::Capabilities {
+//!       ResponseBody::Initialize(types::Capabilities {
 //!         ..Default::default()
-//!       })),
+//!       }),
 //!     );
 //!
 //!     // When you call respond, send_event etc. the message will be wrapped

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-debug-engine"
 description = "Core debugger engine for miden-debug"
-version = "0.8.0"
+version = "0.7.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-debug-engine"
 description = "Core debugger engine for miden-debug"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -27,12 +27,12 @@ clap.workspace = true
 dap = { workspace = true, optional = true, features = ["client"] }
 glob = { version = "0.3.1", optional = true }
 log.workspace = true
-miden-assembly = { version = "0.22", default-features = false }
-miden-assembly-syntax = { version = "0.22", default-features = false }
-miden-core = { version = "0.22", default-features = false }
-miden-debug-types = { version = "0.22", default-features = false }
-miden-mast-package = { version = "0.22", default-features = false }
-miden-processor = { version = "0.22", default-features = false }
+miden-assembly = { version = "0.23", default-features = false }
+miden-assembly-syntax = { version = "0.23", default-features = false }
+miden-core = { version = "0.23", default-features = false }
+miden-debug-types = { version = "0.23", default-features = false }
+miden-mast-package = { version = "0.23", default-features = false }
+miden-processor = { version = "0.23", default-features = false }
 num-traits = "0.2"
 proptest = { version = "1.4", optional = true }
 rustc-demangle = { version = "0.1", features = ["std"] }

--- a/crates/engine/src/debug/breakpoint.rs
+++ b/crates/engine/src/debug/breakpoint.rs
@@ -269,6 +269,7 @@ impl core::fmt::Display for OperationMatcher {
 
 impl FromStr for OperationMatcher {
     type Err = String;
+
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         use miden_core::operations::Operation::*;
         let opcode_parts = name

--- a/crates/engine/src/debug/variables.rs
+++ b/crates/engine/src/debug/variables.rs
@@ -211,24 +211,24 @@ fn resolve_expression_value(
                 values.push(stack.get(index as usize).copied()?);
             }
             DebugExpressionOp::ConstU64(value) => {
-                values.push(Felt::new(value));
+                values.push(Felt::new_unchecked(value));
             }
             DebugExpressionOp::ConstS64(value) => {
-                values.push(Felt::new(value as u64));
+                values.push(Felt::new_unchecked(value as u64));
             }
             DebugExpressionOp::PlusUConst(value) => {
                 let lhs = values.pop()?;
-                values.push(Felt::new(lhs.as_canonical_u64().wrapping_add(value)));
+                values.push(Felt::new_unchecked(lhs.as_canonical_u64().wrapping_add(value)));
             }
             DebugExpressionOp::Minus => {
                 let rhs = values.pop()?.as_canonical_u64();
                 let lhs = values.pop()?.as_canonical_u64();
-                values.push(Felt::new(lhs.wrapping_sub(rhs)));
+                values.push(Felt::new_unchecked(lhs.wrapping_sub(rhs)));
             }
             DebugExpressionOp::Plus => {
                 let rhs = values.pop()?.as_canonical_u64();
                 let lhs = values.pop()?.as_canonical_u64();
-                values.push(Felt::new(lhs.wrapping_add(rhs)));
+                values.push(Felt::new_unchecked(lhs.wrapping_add(rhs)));
             }
             DebugExpressionOp::Deref => {
                 let addr = u32::try_from(values.pop()?.as_canonical_u64()).ok()?;
@@ -247,7 +247,7 @@ fn resolve_expression_value(
                 )?);
             }
             DebugExpressionOp::Address(address) => {
-                values.push(Felt::new(address));
+                values.push(Felt::new_unchecked(address));
             }
             DebugExpressionOp::WasmGlobal(_)
             | DebugExpressionOp::Piece
@@ -310,8 +310,9 @@ fn read_expression_op(reader: &mut SliceReader<'_>) -> Option<DebugExpressionOp>
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use miden_core::serde::ByteWriter;
+
+    use super::*;
 
     #[test]
     fn test_tracker_basic() {
@@ -352,11 +353,11 @@ mod tests {
         let x_snapshot = tracker.get_variable("x").unwrap();
         let value = resolve_variable_value(
             x_snapshot.info.value_location(),
-            &[Felt::new(42)],
+            &[Felt::new_unchecked(42)],
             |_| None,
             |_| None,
         );
-        assert_eq!(value, Some(Felt::new(42)));
+        assert_eq!(value, Some(Felt::new_unchecked(42)));
     }
 
     #[test]
@@ -366,9 +367,9 @@ mod tests {
             DebugVarInfo::new("b", DebugVarLocation::Local(-1)),
         ];
 
-        snapshot_transient_debug_values(&mut infos, &[Felt::new(7)]);
+        snapshot_transient_debug_values(&mut infos, &[Felt::new_unchecked(7)]);
 
-        assert_eq!(infos[0].value_location(), &DebugVarLocation::Const(Felt::new(7)));
+        assert_eq!(infos[0].value_location(), &DebugVarLocation::Const(Felt::new_unchecked(7)));
         assert_eq!(infos[1].value_location(), &DebugVarLocation::Local(-1));
     }
 
@@ -383,11 +384,11 @@ mod tests {
                 byte_offset: 28,
             },
             &[],
-            |addr| (addr == 262_139).then_some(Felt::new(13)),
-            |offset| (offset == -7).then_some(Felt::new(1_048_528)),
+            |addr| (addr == 262_139).then_some(Felt::new_unchecked(13)),
+            |offset| (offset == -7).then_some(Felt::new_unchecked(1_048_528)),
         );
 
-        assert_eq!(value, Some(Felt::new(13)));
+        assert_eq!(value, Some(Felt::new_unchecked(13)));
     }
 
     #[test]
@@ -398,7 +399,7 @@ mod tests {
             let mut events = events.borrow_mut();
             events.insert(
                 RowIndex::from(1),
-                vec![DebugVarInfo::new("x", DebugVarLocation::Const(Felt::new(1)))],
+                vec![DebugVarInfo::new("x", DebugVarLocation::Const(Felt::new_unchecked(1)))],
             );
             events.insert(
                 RowIndex::from(2),
@@ -429,7 +430,7 @@ mod tests {
             |_| None,
         );
 
-        assert_eq!(value, Some(Felt::new(7)));
+        assert_eq!(value, Some(Felt::new_unchecked(7)));
     }
 
     #[test]
@@ -441,10 +442,10 @@ mod tests {
             &DebugVarLocation::Expression(expression),
             &[],
             |_| None,
-            |offset| (offset == 0).then_some(Felt::new(11)),
+            |offset| (offset == 0).then_some(Felt::new_unchecked(11)),
         );
 
-        assert_eq!(value, Some(Felt::new(11)));
+        assert_eq!(value, Some(Felt::new_unchecked(11)));
     }
 
     enum TestExpressionOp {

--- a/crates/engine/src/debug/variables.rs
+++ b/crates/engine/src/debug/variables.rs
@@ -211,24 +211,27 @@ fn resolve_expression_value(
                 values.push(stack.get(index as usize).copied()?);
             }
             DebugExpressionOp::ConstU64(value) => {
-                values.push(Felt::new_unchecked(value));
+                values.push(Felt::new(value).expect("value exceeds field modulus"));
             }
             DebugExpressionOp::ConstS64(value) => {
-                values.push(Felt::new_unchecked(value as u64));
+                values.push(Felt::new(value as u64).expect("value exceeds field modulus"));
             }
             DebugExpressionOp::PlusUConst(value) => {
                 let lhs = values.pop()?;
-                values.push(Felt::new_unchecked(lhs.as_canonical_u64().wrapping_add(value)));
+                values.push(
+                    Felt::new(lhs.as_canonical_u64().wrapping_add(value))
+                        .expect("value exceeds field modulus"),
+                );
             }
             DebugExpressionOp::Minus => {
                 let rhs = values.pop()?.as_canonical_u64();
                 let lhs = values.pop()?.as_canonical_u64();
-                values.push(Felt::new_unchecked(lhs.wrapping_sub(rhs)));
+                values.push(Felt::new(lhs.wrapping_sub(rhs)).expect("value exceeds field modulus"));
             }
             DebugExpressionOp::Plus => {
                 let rhs = values.pop()?.as_canonical_u64();
                 let lhs = values.pop()?.as_canonical_u64();
-                values.push(Felt::new_unchecked(lhs.wrapping_add(rhs)));
+                values.push(Felt::new(lhs.wrapping_add(rhs)).expect("value exceeds field modulus"));
             }
             DebugExpressionOp::Deref => {
                 let addr = u32::try_from(values.pop()?.as_canonical_u64()).ok()?;
@@ -247,7 +250,7 @@ fn resolve_expression_value(
                 )?);
             }
             DebugExpressionOp::Address(address) => {
-                values.push(Felt::new_unchecked(address));
+                values.push(Felt::new(address).expect("value exceeds field modulus"));
             }
             DebugExpressionOp::WasmGlobal(_)
             | DebugExpressionOp::Piece
@@ -353,11 +356,11 @@ mod tests {
         let x_snapshot = tracker.get_variable("x").unwrap();
         let value = resolve_variable_value(
             x_snapshot.info.value_location(),
-            &[Felt::new_unchecked(42)],
+            &[Felt::new(42).expect("value exceeds field modulus")],
             |_| None,
             |_| None,
         );
-        assert_eq!(value, Some(Felt::new_unchecked(42)));
+        assert_eq!(value, Some(Felt::new(42).expect("value exceeds field modulus")));
     }
 
     #[test]
@@ -367,9 +370,15 @@ mod tests {
             DebugVarInfo::new("b", DebugVarLocation::Local(-1)),
         ];
 
-        snapshot_transient_debug_values(&mut infos, &[Felt::new_unchecked(7)]);
+        snapshot_transient_debug_values(
+            &mut infos,
+            &[Felt::new(7).expect("value exceeds field modulus")],
+        );
 
-        assert_eq!(infos[0].value_location(), &DebugVarLocation::Const(Felt::new_unchecked(7)));
+        assert_eq!(
+            infos[0].value_location(),
+            &DebugVarLocation::Const(Felt::new(7).expect("value exceeds field modulus"))
+        );
         assert_eq!(infos[1].value_location(), &DebugVarLocation::Local(-1));
     }
 
@@ -384,11 +393,13 @@ mod tests {
                 byte_offset: 28,
             },
             &[],
-            |addr| (addr == 262_139).then_some(Felt::new_unchecked(13)),
-            |offset| (offset == -7).then_some(Felt::new_unchecked(1_048_528)),
+            |addr| (addr == 262_139).then_some(Felt::new(13).expect("value exceeds field modulus")),
+            |offset| {
+                (offset == -7).then_some(Felt::new(1_048_528).expect("value exceeds field modulus"))
+            },
         );
 
-        assert_eq!(value, Some(Felt::new_unchecked(13)));
+        assert_eq!(value, Some(Felt::new(13).expect("value exceeds field modulus")));
     }
 
     #[test]
@@ -399,7 +410,10 @@ mod tests {
             let mut events = events.borrow_mut();
             events.insert(
                 RowIndex::from(1),
-                vec![DebugVarInfo::new("x", DebugVarLocation::Const(Felt::new_unchecked(1)))],
+                vec![DebugVarInfo::new(
+                    "x",
+                    DebugVarLocation::Const(Felt::new(1).expect("value exceeds field modulus")),
+                )],
             );
             events.insert(
                 RowIndex::from(2),
@@ -430,7 +444,7 @@ mod tests {
             |_| None,
         );
 
-        assert_eq!(value, Some(Felt::new_unchecked(7)));
+        assert_eq!(value, Some(Felt::new(7).expect("value exceeds field modulus")));
     }
 
     #[test]
@@ -442,10 +456,10 @@ mod tests {
             &DebugVarLocation::Expression(expression),
             &[],
             |_| None,
-            |offset| (offset == 0).then_some(Felt::new_unchecked(11)),
+            |offset| (offset == 0).then_some(Felt::new(11).expect("value exceeds field modulus")),
         );
 
-        assert_eq!(value, Some(Felt::new_unchecked(11)));
+        assert_eq!(value, Some(Felt::new(11).expect("value exceeds field modulus")));
     }
 
     enum TestExpressionOp {

--- a/crates/engine/src/exec/config.rs
+++ b/crates/engine/src/exec/config.rs
@@ -235,9 +235,9 @@ mod tests {
 
         let file = ExecutionConfig::parse_str(&text).unwrap();
         let expected_inputs = StackInputs::new(&[
-            RawFelt::new_unchecked(1),
-            RawFelt::new_unchecked(2),
-            RawFelt::new_unchecked(3),
+            RawFelt::new(1).expect("value exceeds field modulus"),
+            RawFelt::new(2).expect("value exceeds field modulus"),
+            RawFelt::new(3).expect("value exceeds field modulus"),
         ])
         .unwrap();
         assert_eq!(file.inputs.as_ref(), expected_inputs.as_ref());
@@ -271,29 +271,29 @@ mod tests {
         .unwrap();
         let file = ExecutionConfig::parse_str(&text).unwrap_or_else(|err| panic!("{err}"));
         let expected_inputs = StackInputs::new(&[
-            RawFelt::new_unchecked(1),
-            RawFelt::new_unchecked(2),
-            RawFelt::new_unchecked(3),
+            RawFelt::new(1).expect("value exceeds field modulus"),
+            RawFelt::new(2).expect("value exceeds field modulus"),
+            RawFelt::new(3).expect("value exceeds field modulus"),
         ])
         .unwrap();
         assert_eq!(file.inputs.as_ref(), expected_inputs.as_ref());
         assert_eq!(
             file.advice_inputs.stack,
             &[
-                RawFelt::new_unchecked(1),
-                RawFelt::new_unchecked(2),
-                RawFelt::new_unchecked(3),
-                RawFelt::new_unchecked(4)
+                RawFelt::new(1).expect("value exceeds field modulus"),
+                RawFelt::new(2).expect("value exceeds field modulus"),
+                RawFelt::new(3).expect("value exceeds field modulus"),
+                RawFelt::new(4).expect("value exceeds field modulus")
             ]
         );
         assert_eq!(
             file.advice_inputs.map.get(&digest).map(|value| value.as_ref()),
             Some(
                 [
-                    RawFelt::new_unchecked(1),
-                    RawFelt::new_unchecked(2),
-                    RawFelt::new_unchecked(3),
-                    RawFelt::new_unchecked(4)
+                    RawFelt::new(1).expect("value exceeds field modulus"),
+                    RawFelt::new(2).expect("value exceeds field modulus"),
+                    RawFelt::new(3).expect("value exceeds field modulus"),
+                    RawFelt::new(4).expect("value exceeds field modulus")
                 ]
                 .as_slice()
             )

--- a/crates/engine/src/exec/config.rs
+++ b/crates/engine/src/exec/config.rs
@@ -234,8 +234,12 @@ mod tests {
         .unwrap();
 
         let file = ExecutionConfig::parse_str(&text).unwrap();
-        let expected_inputs =
-            StackInputs::new(&[RawFelt::new(1), RawFelt::new(2), RawFelt::new(3)]).unwrap();
+        let expected_inputs = StackInputs::new(&[
+            RawFelt::new_unchecked(1),
+            RawFelt::new_unchecked(2),
+            RawFelt::new_unchecked(3),
+        ])
+        .unwrap();
         assert_eq!(file.inputs.as_ref(), expected_inputs.as_ref());
         assert!(file.advice_inputs.stack.is_empty());
         assert!(file.options.enable_tracing());
@@ -266,16 +270,33 @@ mod tests {
         )
         .unwrap();
         let file = ExecutionConfig::parse_str(&text).unwrap_or_else(|err| panic!("{err}"));
-        let expected_inputs =
-            StackInputs::new(&[RawFelt::new(1), RawFelt::new(2), RawFelt::new(3)]).unwrap();
+        let expected_inputs = StackInputs::new(&[
+            RawFelt::new_unchecked(1),
+            RawFelt::new_unchecked(2),
+            RawFelt::new_unchecked(3),
+        ])
+        .unwrap();
         assert_eq!(file.inputs.as_ref(), expected_inputs.as_ref());
         assert_eq!(
             file.advice_inputs.stack,
-            &[RawFelt::new(1), RawFelt::new(2), RawFelt::new(3), RawFelt::new(4)]
+            &[
+                RawFelt::new_unchecked(1),
+                RawFelt::new_unchecked(2),
+                RawFelt::new_unchecked(3),
+                RawFelt::new_unchecked(4)
+            ]
         );
         assert_eq!(
             file.advice_inputs.map.get(&digest).map(|value| value.as_ref()),
-            Some([RawFelt::new(1), RawFelt::new(2), RawFelt::new(3), RawFelt::new(4)].as_slice())
+            Some(
+                [
+                    RawFelt::new_unchecked(1),
+                    RawFelt::new_unchecked(2),
+                    RawFelt::new_unchecked(3),
+                    RawFelt::new_unchecked(4)
+                ]
+                .as_slice()
+            )
         );
         assert!(file.options.enable_tracing());
         assert!(file.options.enable_debugging());

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -231,7 +231,11 @@ fn read_memory_at_current_state(
 
         let felt = processor
             .memory()
-            .read_element(ctx, miden_processor::Felt::new_unchecked(u64::from(expr.addr.addr)))
+            .read_element(
+                ctx,
+                miden_processor::Felt::new(u64::from(expr.addr.addr))
+                    .expect("value exceeds field modulus"),
+            )
             .ok()
             .unwrap_or(miden_processor::Felt::ZERO);
         write_with_format_type!(output, expr, felt.as_canonical_u64());
@@ -248,7 +252,12 @@ fn read_memory_at_current_state(
 
         let word = processor
             .memory()
-            .read_word(ctx, miden_processor::Felt::new_unchecked(u64::from(expr.addr.addr)), cycle)
+            .read_word(
+                ctx,
+                miden_processor::Felt::new(u64::from(expr.addr.addr))
+                    .expect("value exceeds field modulus"),
+                cycle,
+            )
             .ok()
             .unwrap_or_default();
 
@@ -278,7 +287,10 @@ fn read_memory_at_current_state(
             })?;
         let felt = processor
             .memory()
-            .read_element(ctx, miden_processor::Felt::new_unchecked(u64::from(addr)))
+            .read_element(
+                ctx,
+                miden_processor::Felt::new(u64::from(addr)).expect("value exceeds field modulus"),
+            )
             .ok()
             .unwrap_or_default();
         elems.push(felt);
@@ -652,7 +664,10 @@ fn resolve_debug_var_value(
     let read_mem = |addr: u32| -> Option<miden_processor::Felt> {
         processor
             .memory()
-            .read_element(context, miden_processor::Felt::new_unchecked(u64::from(addr)))
+            .read_element(
+                context,
+                miden_processor::Felt::new(u64::from(addr)).expect("value exceeds field modulus"),
+            )
             .ok()
     };
 

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -925,11 +925,9 @@ impl DapExecutor {
         // diverge from a pristine fresh session. Phase 2 (terminate-and-reconnect)
         // solves this by creating a completely fresh host.
         loop {
-            let mut processor = FastProcessor::new(stack_inputs)
-                .with_advice(advice_inputs.clone())
-                .expect("advice inputs should fit advice map limits")
-                .with_options(options)
-                .expect("execution options should be compatible with advice inputs");
+            let mut processor =
+                FastProcessor::new_with_options(stack_inputs, advice_inputs.clone(), options)
+                    .expect("advice inputs should fit advice map limits");
 
             let resume_ctx = processor.get_initial_resume_context(program)?;
             let mut wrapper = DapHostWrapper::new(host);

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -20,8 +20,8 @@ use miden_core::{
     program::Program,
 };
 use miden_processor::{
-    ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, FutureMaybeSend, Host,
-    ProcessorState, ResumeContext, StackInputs, StackOutputs, TraceError,
+    BaseHost, ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, FutureMaybeSend,
+    Host, ProcessorState, ResumeContext, StackInputs, StackOutputs, TraceError,
     advice::{AdviceInputs, AdviceMutation},
     event::EventError,
     mast::MastForest,
@@ -125,23 +125,12 @@ impl<'a, H: Host> DapHostWrapper<'a, H> {
     }
 }
 
-impl<H: Host> Host for DapHostWrapper<'_, H> {
+impl<H: Host> BaseHost for DapHostWrapper<'_, H> {
     fn get_label_and_source_file(
         &self,
         location: &miden_debug_types::Location,
     ) -> (miden_debug_types::SourceSpan, Option<Arc<miden_debug_types::SourceFile>>) {
         self.inner.get_label_and_source_file(location)
-    }
-
-    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        self.inner.get_mast_forest(node_digest)
-    }
-
-    fn on_event(
-        &mut self,
-        process: &ProcessorState<'_>,
-    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        self.inner.on_event(process)
     }
 
     fn on_debug(
@@ -178,6 +167,19 @@ impl<H: Host> Host for DapHostWrapper<'_, H> {
         event_id: miden_core::events::EventId,
     ) -> Option<&miden_core::events::EventName> {
         self.inner.resolve_event(event_id)
+    }
+}
+
+impl<H: Host> Host for DapHostWrapper<'_, H> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        self.inner.get_mast_forest(node_digest)
+    }
+
+    fn on_event(
+        &mut self,
+        process: &ProcessorState<'_>,
+    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
+        self.inner.on_event(process)
     }
 }
 
@@ -229,7 +231,7 @@ fn read_memory_at_current_state(
 
         let felt = processor
             .memory()
-            .read_element(ctx, miden_processor::Felt::new(u64::from(expr.addr.addr)))
+            .read_element(ctx, miden_processor::Felt::new_unchecked(u64::from(expr.addr.addr)))
             .ok()
             .unwrap_or(miden_processor::Felt::ZERO);
         write_with_format_type!(output, expr, felt.as_canonical_u64());
@@ -246,7 +248,7 @@ fn read_memory_at_current_state(
 
         let word = processor
             .memory()
-            .read_word(ctx, miden_processor::Felt::new(u64::from(expr.addr.addr)), cycle)
+            .read_word(ctx, miden_processor::Felt::new_unchecked(u64::from(expr.addr.addr)), cycle)
             .ok()
             .unwrap_or_default();
 
@@ -276,7 +278,7 @@ fn read_memory_at_current_state(
             })?;
         let felt = processor
             .memory()
-            .read_element(ctx, miden_processor::Felt::new(u64::from(addr)))
+            .read_element(ctx, miden_processor::Felt::new_unchecked(u64::from(addr)))
             .ok()
             .unwrap_or_default();
         elems.push(felt);
@@ -650,7 +652,7 @@ fn resolve_debug_var_value(
     let read_mem = |addr: u32| -> Option<miden_processor::Felt> {
         processor
             .memory()
-            .read_element(context, miden_processor::Felt::new(u64::from(addr)))
+            .read_element(context, miden_processor::Felt::new_unchecked(u64::from(addr)))
             .ok()
     };
 
@@ -910,7 +912,9 @@ impl DapExecutor {
         loop {
             let mut processor = FastProcessor::new(stack_inputs)
                 .with_advice(advice_inputs.clone())
-                .with_options(options);
+                .expect("advice inputs should fit advice map limits")
+                .with_options(options)
+                .expect("execution options should be compatible with advice inputs");
 
             let resume_ctx = processor.get_initial_resume_context(program)?;
             let mut wrapper = DapHostWrapper::new(host);
@@ -1432,7 +1436,8 @@ impl DapExecutor {
                                     }
                                     Some(_) => None,
                                     None => Some(
-                                        "No executable Miden operation is mapped to this source file."
+                                        "No executable Miden operation is mapped to this source \
+                                         file."
                                             .into(),
                                     ),
                                 };
@@ -1632,7 +1637,7 @@ impl DapExecutor {
                     stack: StackOutputs::new(&[]).expect("empty stack outputs"),
                     advice: Default::default(),
                     memory: Default::default(),
-                    final_pc_transcript: PrecompileTranscript::default(),
+                    final_precompile_transcript: PrecompileTranscript::default(),
                 });
             }
 
@@ -1666,12 +1671,12 @@ impl DapExecutor {
             let stack = StackOutputs::new(&stack_top)
                 .unwrap_or_else(|_| StackOutputs::new(&[]).expect("empty stack outputs"));
 
-            let (advice, memory, final_pc_transcript) = processor.into_parts();
+            let (advice, memory, final_precompile_transcript) = processor.into_parts();
             return Ok(ExecutionOutput {
                 stack,
                 advice,
                 memory,
-                final_pc_transcript,
+                final_precompile_transcript,
             });
         } // end outer restart loop
     }

--- a/crates/engine/src/exec/diagnostic.rs
+++ b/crates/engine/src/exec/diagnostic.rs
@@ -2,8 +2,8 @@ use std::{sync::Arc, vec::Vec};
 
 use miden_core::{Word, operations::DebugOptions, program::Program};
 use miden_processor::{
-    ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, Felt, FutureMaybeSend, Host,
-    ProcessorState, StackInputs, TraceError,
+    BaseHost, ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, Felt,
+    FutureMaybeSend, Host, ProcessorState, StackInputs, TraceError,
     advice::{AdviceInputs, AdviceMutation},
     event::EventError,
     mast::MastForest,
@@ -62,24 +62,12 @@ impl<'a, H: Host> DiagnosticHostWrapper<'a, H> {
     }
 }
 
-impl<H: Host> Host for DiagnosticHostWrapper<'_, H> {
+impl<H: Host> BaseHost for DiagnosticHostWrapper<'_, H> {
     fn get_label_and_source_file(
         &self,
         location: &miden_debug_types::Location,
     ) -> (miden_debug_types::SourceSpan, Option<Arc<miden_debug_types::SourceFile>>) {
         self.inner.get_label_and_source_file(location)
-    }
-
-    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        self.inner.get_mast_forest(node_digest)
-    }
-
-    fn on_event(
-        &mut self,
-        process: &ProcessorState<'_>,
-    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        self.capture_state(process);
-        self.inner.on_event(process)
     }
 
     fn on_debug(
@@ -108,6 +96,20 @@ impl<H: Host> Host for DiagnosticHostWrapper<'_, H> {
         event_id: miden_core::events::EventId,
     ) -> Option<&miden_core::events::EventName> {
         self.inner.resolve_event(event_id)
+    }
+}
+
+impl<H: Host> Host for DiagnosticHostWrapper<'_, H> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        self.inner.get_mast_forest(node_digest)
+    }
+
+    fn on_event(
+        &mut self,
+        process: &ProcessorState<'_>,
+    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
+        self.capture_state(process);
+        self.inner.on_event(process)
     }
 }
 
@@ -164,7 +166,9 @@ impl DiagnosticExecutor {
             let options = self.options.with_debugging(true).with_tracing(true);
             let processor = FastProcessor::new(self.stack_inputs)
                 .with_advice(self.advice_inputs)
-                .with_options(options);
+                .expect("advice inputs should fit advice map limits")
+                .with_options(options)
+                .expect("execution options should be compatible with advice inputs");
 
             let mut wrapper = DiagnosticHostWrapper::new(host);
 

--- a/crates/engine/src/exec/diagnostic.rs
+++ b/crates/engine/src/exec/diagnostic.rs
@@ -164,11 +164,9 @@ impl DiagnosticExecutor {
         async move {
             // Enable debugging and tracing for richer diagnostics.
             let options = self.options.with_debugging(true).with_tracing(true);
-            let processor = FastProcessor::new(self.stack_inputs)
-                .with_advice(self.advice_inputs)
-                .expect("advice inputs should fit advice map limits")
-                .with_options(options)
-                .expect("execution options should be compatible with advice inputs");
+            let processor =
+                FastProcessor::new_with_options(self.stack_inputs, self.advice_inputs, options)
+                    .expect("advice inputs should fit advice map limits");
 
             let mut wrapper = DiagnosticHostWrapper::new(host);
 

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -176,11 +176,8 @@ impl Executor {
         let debug_var_events: Rc<RefCell<BTreeMap<RowIndex, Vec<DebugVarInfo>>>> =
             Rc::new(Default::default());
 
-        let mut processor = FastProcessor::new(self.stack)
-            .with_advice(self.advice)
+        let mut processor = FastProcessor::new_with_options(self.stack, self.advice, self.options)
             .expect("advice inputs should fit advice map limits")
-            .with_options(self.options)
-            .expect("execution options should be compatible with advice inputs")
             .with_debugging(true)
             .with_tracing(true);
 
@@ -244,11 +241,8 @@ impl Executor {
         let trace_events: Rc<RefCell<BTreeMap<RowIndex, TraceEvent>>> = Rc::new(Default::default());
         register_builtin_trace_handlers(&mut host, Rc::clone(&trace_events));
 
-        let mut processor = FastProcessor::new(self.stack)
-            .with_advice(self.advice)
+        let mut processor = FastProcessor::new_with_options(self.stack, self.advice, self.options)
             .expect("advice inputs should fit advice map limits")
-            .with_options(self.options)
-            .expect("execution options should be compatible with advice inputs")
             .with_debugging(true)
             .with_tracing(true);
 

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -178,7 +178,9 @@ impl Executor {
 
         let mut processor = FastProcessor::new(self.stack)
             .with_advice(self.advice)
+            .expect("advice inputs should fit advice map limits")
             .with_options(self.options)
+            .expect("execution options should be compatible with advice inputs")
             .with_debugging(true)
             .with_tracing(true);
 
@@ -244,7 +246,9 @@ impl Executor {
 
         let mut processor = FastProcessor::new(self.stack)
             .with_advice(self.advice)
+            .expect("advice inputs should fit advice map limits")
             .with_options(self.options)
+            .expect("execution options should be compatible with advice inputs")
             .with_debugging(true)
             .with_tracing(true);
 

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -11,8 +11,8 @@ use miden_core::{
 };
 use miden_debug_types::{Location, SourceFile, SourceSpan};
 use miden_processor::{
-    ExecutionError, FutureMaybeSend, Host, MastForestStore, MemMastForestStore, ProcessorState,
-    TraceError,
+    BaseHost, ExecutionError, FutureMaybeSend, Host, MastForestStore, MemMastForestStore,
+    ProcessorState, TraceError,
     advice::AdviceMutation,
     event::{EventError, EventHandler, EventHandlerRegistry},
     mast::MastForest,
@@ -105,7 +105,7 @@ where
     }
 }
 
-impl<S> Host for DebuggerHost<S>
+impl<S> BaseHost for DebuggerHost<S>
 where
     S: SourceManager + ?Sized,
 {
@@ -118,6 +118,25 @@ where
         (span, maybe_file)
     }
 
+    fn on_trace(&mut self, process: &ProcessorState<'_>, trace_id: u32) -> Result<(), TraceError> {
+        let event = TraceEvent::from(trace_id);
+        if let Some(handlers) = self.tracing_callbacks.get_mut(&trace_id) {
+            for handler in handlers.iter_mut() {
+                handler(process, event);
+            }
+        }
+        Ok(())
+    }
+
+    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        self.event_handlers.resolve_event(event_id)
+    }
+}
+
+impl<S> Host for DebuggerHost<S>
+where
+    S: SourceManager + ?Sized,
+{
     fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
         std::future::ready(self.store.get(node_digest))
     }
@@ -144,19 +163,5 @@ where
             Err(err) => Err(err),
         };
         std::future::ready(result)
-    }
-
-    fn on_trace(&mut self, process: &ProcessorState<'_>, trace_id: u32) -> Result<(), TraceError> {
-        let event = TraceEvent::from(trace_id);
-        if let Some(handlers) = self.tracing_callbacks.get_mut(&trace_id) {
-            for handler in handlers.iter_mut() {
-                handler(process, event);
-            }
-        }
-        Ok(())
-    }
-
-    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
-        self.event_handlers.resolve_event(event_id)
     }
 }

--- a/crates/engine/src/exec/query.rs
+++ b/crates/engine/src/exec/query.rs
@@ -2,9 +2,8 @@ use miden_core::{Felt, Word};
 use miden_processor::{ContextId, MemoryError, ProcessorState, trace::RowIndex};
 use smallvec::SmallVec;
 
-use crate::{FromMidenRepr, NativePtr};
-
 use super::trace::MemoryReadError;
+use crate::{FromMidenRepr, NativePtr};
 
 pub trait DebugQuery {
     fn state(&self) -> ProcessorState<'_>;

--- a/crates/engine/src/exec/trace.rs
+++ b/crates/engine/src/exec/trace.rs
@@ -92,7 +92,11 @@ impl ExecutionTrace {
     ) -> Option<Word> {
         const ZERO: Word = Word::new([Felt::ZERO; 4]);
 
-        match self.processor.memory().read_word(ctx, Felt::new_unchecked(addr as u64), clk) {
+        match self.processor.memory().read_word(
+            ctx,
+            Felt::new(addr as u64).expect("value exceeds field modulus"),
+            clk,
+        ) {
             Ok(word) => Some(word),
             Err(_) => Some(ZERO),
         }
@@ -106,7 +110,10 @@ impl ExecutionTrace {
         ctx: ContextId,
         _clk: RowIndex,
     ) -> Option<Felt> {
-        self.processor.memory().read_element(ctx, Felt::new_unchecked(addr as u64)).ok()
+        self.processor
+            .memory()
+            .read_element(ctx, Felt::new(addr as u64).expect("value exceeds field modulus"))
+            .ok()
     }
 
     /// Read a raw byte vector from `addr`, under `ctx`, at cycle `clk`, sufficient to hold a value

--- a/crates/engine/src/exec/trace.rs
+++ b/crates/engine/src/exec/trace.rs
@@ -92,7 +92,7 @@ impl ExecutionTrace {
     ) -> Option<Word> {
         const ZERO: Word = Word::new([Felt::ZERO; 4]);
 
-        match self.processor.memory().read_word(ctx, Felt::new(addr as u64), clk) {
+        match self.processor.memory().read_word(ctx, Felt::new_unchecked(addr as u64), clk) {
             Ok(word) => Some(word),
             Err(_) => Some(ZERO),
         }
@@ -106,7 +106,7 @@ impl ExecutionTrace {
         ctx: ContextId,
         _clk: RowIndex,
     ) -> Option<Felt> {
-        self.processor.memory().read_element(ctx, Felt::new(addr as u64)).ok()
+        self.processor.memory().read_element(ctx, Felt::new_unchecked(addr as u64)).ok()
     }
 
     /// Read a raw byte vector from `addr`, under `ctx`, at cycle `clk`, sufficient to hold a value

--- a/crates/engine/src/felt.rs
+++ b/crates/engine/src/felt.rs
@@ -23,14 +23,20 @@ pub trait ToMidenRepr {
         let mut felts = SmallVec::<[RawFelt; 4]>::with_capacity(num_felts);
         let (chunks, remainder) = bytes.as_chunks::<4>();
         for chunk in chunks {
-            felts.push(RawFelt::new_unchecked(u32::from_ne_bytes(*chunk) as u64));
+            felts.push(
+                RawFelt::new(u32::from_ne_bytes(*chunk) as u64)
+                    .expect("value exceeds field modulus"),
+            );
         }
         if !remainder.is_empty() {
             let mut chunk = [0u8; 4];
             for (i, byte) in remainder.iter().enumerate() {
                 chunk[i] = *byte;
             }
-            felts.push(RawFelt::new_unchecked(u32::from_ne_bytes(chunk) as u64));
+            felts.push(
+                RawFelt::new(u32::from_ne_bytes(chunk) as u64)
+                    .expect("value exceeds field modulus"),
+            );
         }
         felts
     }
@@ -143,11 +149,11 @@ impl ToMidenRepr for bool {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u64)]
+        smallvec![RawFelt::new(*self as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u64));
+        stack.push(RawFelt::new(*self as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -188,11 +194,11 @@ impl ToMidenRepr for u8 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u64)]
+        smallvec![RawFelt::new(*self as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u64));
+        stack.push(RawFelt::new(*self as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -222,11 +228,11 @@ impl ToMidenRepr for i8 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u8 as u64)]
+        smallvec![RawFelt::new(*self as u8 as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u8 as u64));
+        stack.push(RawFelt::new(*self as u8 as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -256,11 +262,11 @@ impl ToMidenRepr for u16 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u64)]
+        smallvec![RawFelt::new(*self as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u64));
+        stack.push(RawFelt::new(*self as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -290,11 +296,11 @@ impl ToMidenRepr for i16 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u16 as u64)]
+        smallvec![RawFelt::new(*self as u16 as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u16 as u64));
+        stack.push(RawFelt::new(*self as u16 as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -324,11 +330,11 @@ impl ToMidenRepr for u32 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u64)]
+        smallvec![RawFelt::new(*self as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u64));
+        stack.push(RawFelt::new(*self as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -358,11 +364,11 @@ impl ToMidenRepr for i32 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new_unchecked(*self as u32 as u64)]
+        smallvec![RawFelt::new(*self as u32 as u64).expect("value exceeds field modulus")]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new_unchecked(*self as u32 as u64));
+        stack.push(RawFelt::new(*self as u32 as u64).expect("value exceeds field modulus"));
     }
 }
 
@@ -394,7 +400,10 @@ impl ToMidenRepr for u64 {
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
         let lo = (*self as u32) as u64;
         let hi = *self >> 32;
-        smallvec![RawFelt::new_unchecked(lo), RawFelt::new_unchecked(hi)]
+        smallvec![
+            RawFelt::new(lo).expect("value exceeds field modulus"),
+            RawFelt::new(hi).expect("value exceeds field modulus"),
+        ]
     }
 }
 
@@ -450,10 +459,13 @@ impl ToMidenRepr for u128 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        let lo_lo = RawFelt::new_unchecked((*self as u32) as u64);
-        let lo_hi = RawFelt::new_unchecked(((*self >> 32) as u32) as u64);
-        let hi_lo = RawFelt::new_unchecked(((*self >> 64) as u32) as u64);
-        let hi_hi = RawFelt::new_unchecked(((*self >> 96) as u32) as u64);
+        let lo_lo = RawFelt::new((*self as u32) as u64).expect("value exceeds field modulus");
+        let lo_hi =
+            RawFelt::new(((*self >> 32) as u32) as u64).expect("value exceeds field modulus");
+        let hi_lo =
+            RawFelt::new(((*self >> 64) as u32) as u64).expect("value exceeds field modulus");
+        let hi_hi =
+            RawFelt::new(((*self >> 96) as u32) as u64).expect("value exceeds field modulus");
         smallvec![lo_lo, lo_hi, hi_lo, hi_hi]
     }
 }
@@ -654,16 +666,16 @@ pub fn bytes_to_words(bytes: &[u8]) -> Vec<[RawFelt; 4]> {
     let (chunks, remainder) = buf.as_chunks::<4>();
     for chunk in chunks {
         words.push([
-            RawFelt::new_unchecked(chunk[3] as u64),
-            RawFelt::new_unchecked(chunk[2] as u64),
-            RawFelt::new_unchecked(chunk[1] as u64),
-            RawFelt::new_unchecked(chunk[0] as u64),
+            RawFelt::new(chunk[3] as u64).expect("value exceeds field modulus"),
+            RawFelt::new(chunk[2] as u64).expect("value exceeds field modulus"),
+            RawFelt::new(chunk[1] as u64).expect("value exceeds field modulus"),
+            RawFelt::new(chunk[0] as u64).expect("value exceeds field modulus"),
         ]);
     }
     if !remainder.is_empty() {
         let mut word = [RawFelt::ZERO; 4];
         for (i, n) in remainder.iter().enumerate() {
-            word[i] = RawFelt::new_unchecked(*n as u64);
+            word[i] = RawFelt::new(*n as u64).expect("value exceeds field modulus");
         }
         word.reverse();
         words.push(word);
@@ -678,7 +690,7 @@ pub struct Felt(pub RawFelt);
 impl Felt {
     #[inline]
     pub fn new(value: u64) -> Self {
-        Self(RawFelt::new_unchecked(value))
+        Self(RawFelt::new(value).expect("value exceeds field modulus"))
     }
 }
 
@@ -693,7 +705,7 @@ impl<'de> Deserialize<'de> for Felt {
                     "invalid field element value: exceeds the field modulus",
                 ))
             } else {
-                Ok(Felt(RawFelt::new_unchecked(n)))
+                Ok(Felt(RawFelt::new(n).expect("value exceeds field modulus")))
             }
         })
     }
@@ -740,7 +752,7 @@ impl core::str::FromStr for Felt {
         if value >= RawFelt::ORDER_U64 {
             Err("invalid field element value: exceeds the field modulus".to_string())
         } else {
-            Ok(Felt(RawFelt::new_unchecked(value)))
+            Ok(Felt(RawFelt::new(value).expect("value exceeds field modulus")))
         }
     }
 }
@@ -753,55 +765,55 @@ impl From<Felt> for miden_processor::Felt {
 
 impl From<bool> for Felt {
     fn from(b: bool) -> Self {
-        Self(RawFelt::new_unchecked(b as u64))
+        Self(RawFelt::new(b as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<u8> for Felt {
     fn from(t: u8) -> Self {
-        Self(RawFelt::new_unchecked(t as u64))
+        Self(RawFelt::new(t as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<i8> for Felt {
     fn from(t: i8) -> Self {
-        Self(RawFelt::new_unchecked(t as u8 as u64))
+        Self(RawFelt::new(t as u8 as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<i16> for Felt {
     fn from(t: i16) -> Self {
-        Self(RawFelt::new_unchecked(t as u16 as u64))
+        Self(RawFelt::new(t as u16 as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<u16> for Felt {
     fn from(t: u16) -> Self {
-        Self(RawFelt::new_unchecked(t as u64))
+        Self(RawFelt::new(t as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<i32> for Felt {
     fn from(t: i32) -> Self {
-        Self(RawFelt::new_unchecked(t as u32 as u64))
+        Self(RawFelt::new(t as u32 as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<u32> for Felt {
     fn from(t: u32) -> Self {
-        Self(RawFelt::new_unchecked(t as u64))
+        Self(RawFelt::new(t as u64).expect("value exceeds field modulus"))
     }
 }
 
 impl From<u64> for Felt {
     fn from(t: u64) -> Self {
-        Self(RawFelt::new_unchecked(t))
+        Self(RawFelt::new(t).expect("value exceeds field modulus"))
     }
 }
 
 impl From<i64> for Felt {
     fn from(t: i64) -> Self {
-        Self(RawFelt::new_unchecked(t as u64))
+        Self(RawFelt::new(t as u64).expect("value exceeds field modulus"))
     }
 }
 
@@ -867,7 +879,9 @@ impl Arbitrary for Felt {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (0u64..RawFelt::ORDER_U64).prop_map(|v| Felt(RawFelt::new_unchecked(v))).boxed()
+        (0u64..RawFelt::ORDER_U64)
+            .prop_map(|v| Felt(RawFelt::new(v).expect("value exceeds field modulus")))
+            .boxed()
     }
 }
 

--- a/crates/engine/src/felt.rs
+++ b/crates/engine/src/felt.rs
@@ -23,14 +23,14 @@ pub trait ToMidenRepr {
         let mut felts = SmallVec::<[RawFelt; 4]>::with_capacity(num_felts);
         let (chunks, remainder) = bytes.as_chunks::<4>();
         for chunk in chunks {
-            felts.push(RawFelt::new(u32::from_ne_bytes(*chunk) as u64));
+            felts.push(RawFelt::new_unchecked(u32::from_ne_bytes(*chunk) as u64));
         }
         if !remainder.is_empty() {
             let mut chunk = [0u8; 4];
             for (i, byte) in remainder.iter().enumerate() {
                 chunk[i] = *byte;
             }
-            felts.push(RawFelt::new(u32::from_ne_bytes(chunk) as u64));
+            felts.push(RawFelt::new_unchecked(u32::from_ne_bytes(chunk) as u64));
         }
         felts
     }
@@ -143,11 +143,11 @@ impl ToMidenRepr for bool {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u64));
+        stack.push(RawFelt::new_unchecked(*self as u64));
     }
 }
 
@@ -188,11 +188,11 @@ impl ToMidenRepr for u8 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u64));
+        stack.push(RawFelt::new_unchecked(*self as u64));
     }
 }
 
@@ -222,11 +222,11 @@ impl ToMidenRepr for i8 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u8 as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u8 as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u8 as u64));
+        stack.push(RawFelt::new_unchecked(*self as u8 as u64));
     }
 }
 
@@ -256,11 +256,11 @@ impl ToMidenRepr for u16 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u64));
+        stack.push(RawFelt::new_unchecked(*self as u64));
     }
 }
 
@@ -290,11 +290,11 @@ impl ToMidenRepr for i16 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u16 as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u16 as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u16 as u64));
+        stack.push(RawFelt::new_unchecked(*self as u16 as u64));
     }
 }
 
@@ -324,11 +324,11 @@ impl ToMidenRepr for u32 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u64));
+        stack.push(RawFelt::new_unchecked(*self as u64));
     }
 }
 
@@ -358,11 +358,11 @@ impl ToMidenRepr for i32 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        smallvec![RawFelt::new(*self as u32 as u64)]
+        smallvec![RawFelt::new_unchecked(*self as u32 as u64)]
     }
 
     fn push_to_operand_stack(&self, stack: &mut Vec<RawFelt>) {
-        stack.push(RawFelt::new(*self as u32 as u64));
+        stack.push(RawFelt::new_unchecked(*self as u32 as u64));
     }
 }
 
@@ -394,7 +394,7 @@ impl ToMidenRepr for u64 {
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
         let lo = (*self as u32) as u64;
         let hi = *self >> 32;
-        smallvec![RawFelt::new(lo), RawFelt::new(hi)]
+        smallvec![RawFelt::new_unchecked(lo), RawFelt::new_unchecked(hi)]
     }
 }
 
@@ -450,10 +450,10 @@ impl ToMidenRepr for u128 {
     }
 
     fn to_felts(&self) -> SmallVec<[RawFelt; 4]> {
-        let lo_lo = RawFelt::new((*self as u32) as u64);
-        let lo_hi = RawFelt::new(((*self >> 32) as u32) as u64);
-        let hi_lo = RawFelt::new(((*self >> 64) as u32) as u64);
-        let hi_hi = RawFelt::new(((*self >> 96) as u32) as u64);
+        let lo_lo = RawFelt::new_unchecked((*self as u32) as u64);
+        let lo_hi = RawFelt::new_unchecked(((*self >> 32) as u32) as u64);
+        let hi_lo = RawFelt::new_unchecked(((*self >> 64) as u32) as u64);
+        let hi_hi = RawFelt::new_unchecked(((*self >> 96) as u32) as u64);
         smallvec![lo_lo, lo_hi, hi_lo, hi_hi]
     }
 }
@@ -654,16 +654,16 @@ pub fn bytes_to_words(bytes: &[u8]) -> Vec<[RawFelt; 4]> {
     let (chunks, remainder) = buf.as_chunks::<4>();
     for chunk in chunks {
         words.push([
-            RawFelt::new(chunk[3] as u64),
-            RawFelt::new(chunk[2] as u64),
-            RawFelt::new(chunk[1] as u64),
-            RawFelt::new(chunk[0] as u64),
+            RawFelt::new_unchecked(chunk[3] as u64),
+            RawFelt::new_unchecked(chunk[2] as u64),
+            RawFelt::new_unchecked(chunk[1] as u64),
+            RawFelt::new_unchecked(chunk[0] as u64),
         ]);
     }
     if !remainder.is_empty() {
         let mut word = [RawFelt::ZERO; 4];
         for (i, n) in remainder.iter().enumerate() {
-            word[i] = RawFelt::new(*n as u64);
+            word[i] = RawFelt::new_unchecked(*n as u64);
         }
         word.reverse();
         words.push(word);
@@ -678,7 +678,7 @@ pub struct Felt(pub RawFelt);
 impl Felt {
     #[inline]
     pub fn new(value: u64) -> Self {
-        Self(RawFelt::new(value))
+        Self(RawFelt::new_unchecked(value))
     }
 }
 
@@ -693,7 +693,7 @@ impl<'de> Deserialize<'de> for Felt {
                     "invalid field element value: exceeds the field modulus",
                 ))
             } else {
-                Ok(Felt(RawFelt::new(n)))
+                Ok(Felt(RawFelt::new_unchecked(n)))
             }
         })
     }
@@ -740,7 +740,7 @@ impl core::str::FromStr for Felt {
         if value >= RawFelt::ORDER_U64 {
             Err("invalid field element value: exceeds the field modulus".to_string())
         } else {
-            Ok(Felt(RawFelt::new(value)))
+            Ok(Felt(RawFelt::new_unchecked(value)))
         }
     }
 }
@@ -753,55 +753,55 @@ impl From<Felt> for miden_processor::Felt {
 
 impl From<bool> for Felt {
     fn from(b: bool) -> Self {
-        Self(RawFelt::new(b as u64))
+        Self(RawFelt::new_unchecked(b as u64))
     }
 }
 
 impl From<u8> for Felt {
     fn from(t: u8) -> Self {
-        Self(RawFelt::new(t as u64))
+        Self(RawFelt::new_unchecked(t as u64))
     }
 }
 
 impl From<i8> for Felt {
     fn from(t: i8) -> Self {
-        Self(RawFelt::new(t as u8 as u64))
+        Self(RawFelt::new_unchecked(t as u8 as u64))
     }
 }
 
 impl From<i16> for Felt {
     fn from(t: i16) -> Self {
-        Self(RawFelt::new(t as u16 as u64))
+        Self(RawFelt::new_unchecked(t as u16 as u64))
     }
 }
 
 impl From<u16> for Felt {
     fn from(t: u16) -> Self {
-        Self(RawFelt::new(t as u64))
+        Self(RawFelt::new_unchecked(t as u64))
     }
 }
 
 impl From<i32> for Felt {
     fn from(t: i32) -> Self {
-        Self(RawFelt::new(t as u32 as u64))
+        Self(RawFelt::new_unchecked(t as u32 as u64))
     }
 }
 
 impl From<u32> for Felt {
     fn from(t: u32) -> Self {
-        Self(RawFelt::new(t as u64))
+        Self(RawFelt::new_unchecked(t as u64))
     }
 }
 
 impl From<u64> for Felt {
     fn from(t: u64) -> Self {
-        Self(RawFelt::new(t))
+        Self(RawFelt::new_unchecked(t))
     }
 }
 
 impl From<i64> for Felt {
     fn from(t: i64) -> Self {
-        Self(RawFelt::new(t as u64))
+        Self(RawFelt::new_unchecked(t as u64))
     }
 }
 
@@ -867,7 +867,7 @@ impl Arbitrary for Felt {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (0u64..RawFelt::ORDER_U64).prop_map(|v| Felt(RawFelt::new(v))).boxed()
+        (0u64..RawFelt::ORDER_U64).prop_map(|v| Felt(RawFelt::new_unchecked(v))).boxed()
     }
 }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -4,12 +4,12 @@ pub mod felt;
 #[cfg(test)]
 mod test_utils;
 
+pub use miden_core::events;
+pub use miden_debug_types as debug_types;
+pub use miden_processor as processor;
+
 pub use self::{
     debug::*,
     exec::*,
     felt::{Felt, FromMidenRepr, ToMidenRepr, bytes_to_words, push_wasm_ty_to_operand_stack},
 };
-
-pub use miden_core::events;
-pub use miden_debug_types as debug_types;
-pub use miden_processor as processor;

--- a/src/dap_server.rs
+++ b/src/dap_server.rs
@@ -11,7 +11,7 @@ use miden_core::{
 };
 use miden_debug_types::{Location, SourceFile, SourceManagerExt, SourceSpan};
 use miden_processor::{
-    DefaultDebugHandler, DefaultHost, FutureMaybeSend, Host, ProcessorState, StackInputs,
+    BaseHost, DefaultDebugHandler, DefaultHost, FutureMaybeSend, Host, ProcessorState, StackInputs,
     TraceError, advice::AdviceMutation, event::EventError,
 };
 
@@ -83,7 +83,7 @@ impl StandaloneDapHost {
     }
 }
 
-impl Host for StandaloneDapHost {
+impl BaseHost for StandaloneDapHost {
     fn get_label_and_source_file(
         &self,
         location: &Location,
@@ -91,17 +91,6 @@ impl Host for StandaloneDapHost {
         let maybe_file = self.ensure_source_file(location);
         let span = self.source_manager.location_to_span(location.clone()).unwrap_or_default();
         (span, maybe_file)
-    }
-
-    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        self.inner.get_mast_forest(node_digest)
-    }
-
-    fn on_event(
-        &mut self,
-        process: &ProcessorState<'_>,
-    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        self.inner.on_event(process)
     }
 
     fn on_debug(
@@ -118,6 +107,19 @@ impl Host for StandaloneDapHost {
 
     fn resolve_event(&self, event_id: EventId) -> Option<&miden_core::events::EventName> {
         self.inner.resolve_event(event_id)
+    }
+}
+
+impl Host for StandaloneDapHost {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        self.inner.get_mast_forest(node_digest)
+    }
+
+    fn on_event(
+        &mut self,
+        process: &ProcessorState<'_>,
+    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
+        self.inner.on_event(process)
     }
 }
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -725,7 +725,7 @@ impl State {
         let context = executor.current_context;
         let memory = executor.processor.memory();
         let read_element = |addr: u32| -> Option<Felt> {
-            memory.read_element(context, Felt::new(addr as u64)).ok()
+            memory.read_element(context, Felt::new_unchecked(addr as u64)).ok()
         };
         let mut output = String::new();
         if expr.count > 1 {
@@ -746,7 +746,7 @@ impl State {
                 return Err("read failed: type 'word' must be aligned to a word boundary".into());
             }
             let word = memory
-                .read_word(context, Felt::new(expr.addr.addr as u64), cycle)
+                .read_word(context, Felt::new_unchecked(expr.addr.addr as u64), cycle)
                 .unwrap_or_default();
             output.push('[');
             for (i, elem) in word.iter().enumerate() {
@@ -840,7 +840,11 @@ impl State {
 
         // Use live processor state, not the pre-recorded trace, for current-cycle values.
         let read_mem = |addr: u32| -> Option<Felt> {
-            executor.processor.memory().read_element(context, Felt::new(addr as u64)).ok()
+            executor
+                .processor
+                .memory()
+                .read_element(context, Felt::new_unchecked(addr as u64))
+                .ok()
         };
 
         let current_source = if show_all {
@@ -1066,7 +1070,7 @@ fn convert_ui_state(
         })
         .collect();
 
-    let current_stack = snapshot.current_stack.iter().copied().map(Felt::new).collect();
+    let current_stack = snapshot.current_stack.iter().copied().map(Felt::new_unchecked).collect();
 
     RemoteSnapshot {
         callstack: CallStack::from_remote_frames(call_frames),

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -725,7 +725,9 @@ impl State {
         let context = executor.current_context;
         let memory = executor.processor.memory();
         let read_element = |addr: u32| -> Option<Felt> {
-            memory.read_element(context, Felt::new_unchecked(addr as u64)).ok()
+            memory
+                .read_element(context, Felt::new(addr as u64).expect("value exceeds field modulus"))
+                .ok()
         };
         let mut output = String::new();
         if expr.count > 1 {
@@ -746,7 +748,11 @@ impl State {
                 return Err("read failed: type 'word' must be aligned to a word boundary".into());
             }
             let word = memory
-                .read_word(context, Felt::new_unchecked(expr.addr.addr as u64), cycle)
+                .read_word(
+                    context,
+                    Felt::new(expr.addr.addr as u64).expect("value exceeds field modulus"),
+                    cycle,
+                )
                 .unwrap_or_default();
             output.push('[');
             for (i, elem) in word.iter().enumerate() {
@@ -843,7 +849,7 @@ impl State {
             executor
                 .processor
                 .memory()
-                .read_element(context, Felt::new_unchecked(addr as u64))
+                .read_element(context, Felt::new(addr as u64).expect("value exceeds field modulus"))
                 .ok()
         };
 
@@ -1070,7 +1076,12 @@ fn convert_ui_state(
         })
         .collect();
 
-    let current_stack = snapshot.current_stack.iter().copied().map(Felt::new_unchecked).collect();
+    let current_stack = snapshot
+        .current_stack
+        .iter()
+        .copied()
+        .map(|v| Felt::new(v).expect("value exceeds field modulus"))
+        .collect();
 
     RemoteSnapshot {
         callstack: CallStack::from_remote_frames(call_frames),


### PR DESCRIPTION
This PR is needed in order to update `miden-client` to the latest protocol version https://github.com/0xMiden/miden-client/pull/2185

Bumps miden-core, miden-processor, miden-debug-types, miden-mast-package, miden-assembly, and miden-assembly-syntax from 0.22 to 0.23, and the workspace version from 0.7.1 to 0.8.0.

Migrations forced by the dep bump:
- Split `Host` impls into `BaseHost` + `Host` (BaseHost holds `get_label_and_source_file`, `on_debug`, `on_trace`, `resolve_event`; Host keeps `get_mast_forest` and `on_event`).
- Replace `Felt::new(..)` / `RawFelt::new(..)` with the now-infallible `new_unchecked(..)` at preserved-behavior call sites.
- Adapt to `FastProcessor::with_advice` / `with_options` returning `Result<Self, AdviceError>` (unwrap with `.expect` to match the prior infallible behavior).
- Rename `ExecutionOutput.final_pc_transcript` to `final_precompile_transcript`.

Also fixes a pre-existing dap doctest (mark as no_run; the example reads a file that doesn't exist) that was broken on `next`.