### PR TITLE
fix: `read_from_rust_memory`

### DIFF
--- a/crates/engine/src/exec/query.rs
+++ b/crates/engine/src/exec/query.rs
@@ -49,8 +49,8 @@ pub trait DebugQuery {
         assert_eq!(ptr.offset, 0, "support for unaligned reads is not yet implemented");
         let size = <T as FromMidenRepr>::size_in_felts();
         let mut felts = SmallVec::<[_; 4]>::with_capacity(size);
-        for _ in 0..(size as u32) {
-            felts.push(self.read_memory_element(addr)?);
+        for index in 0..(size as u32) {
+            felts.push(self.read_memory_element(ptr.addr + index)?);
         }
         Some(T::from_felts(&felts))
     }

--- a/crates/engine/src/exec/query.rs
+++ b/crates/engine/src/exec/query.rs
@@ -50,7 +50,7 @@ pub trait DebugQuery {
         let size = <T as FromMidenRepr>::size_in_felts();
         let mut felts = SmallVec::<[_; 4]>::with_capacity(size);
         for index in 0..(size as u32) {
-            felts.push(self.read_memory_element(ptr.addr + index)?);
+            felts.push(self.read_memory_element(ptr.addr + index).unwrap_or_default());
         }
         Some(T::from_felts(&felts))
     }

--- a/crates/engine/src/exec/trace.rs
+++ b/crates/engine/src/exec/trace.rs
@@ -259,4 +259,19 @@ end
 
         assert_eq!(trace.read_from_rust_memory::<u64>(12), Some(0x0807_0605_0403_0201));
     }
+
+    #[test]
+    fn debug_query_reads_uninitialized_rust_memory_as_zero() {
+        let trace = execute_trace(
+            r#"
+begin
+    push.67305985
+    push.3
+    mem_store
+end
+"#,
+        );
+
+        assert_eq!(trace.read_from_rust_memory::<u64>(12), Some(0x0000_0000_0403_0201));
+    }
 }

--- a/crates/engine/src/exec/trace.rs
+++ b/crates/engine/src/exec/trace.rs
@@ -168,7 +168,7 @@ mod tests {
     use miden_processor::{ContextId, trace::RowIndex};
 
     use super::ExecutionTrace;
-    use crate::{Executor, debug::NativePtr, felt::ToMidenRepr};
+    use crate::{Executor, debug::NativePtr, exec::DebugQuery, felt::ToMidenRepr};
 
     fn empty_trace() -> ExecutionTrace {
         ExecutionTrace {
@@ -239,5 +239,24 @@ end
 
         assert_eq!(u16_bytes, vec![0x34, 0x12]);
         assert_eq!(u64_bytes, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn debug_query_reads_rust_memory_from_byte_address() {
+        let trace = execute_trace(
+            r#"
+begin
+    push.67305985
+    push.3
+    mem_store
+
+    push.134678021
+    push.4
+    mem_store
+end
+"#,
+        );
+
+        assert_eq!(trace.read_from_rust_memory::<u64>(12), Some(0x0807_0605_0403_0201));
     }
 }


### PR DESCRIPTION
Discovered in https://github.com/0xMiden/compiler/pull/1146