### PR TITLE
feat: add python scripting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,8 @@ dependencies = [
  "miden-mast-package",
  "miden-package-registry",
  "miden-processor",
+ "pyo3",
+ "pyo3-build-config",
  "ratatui",
  "rustyline",
  "signal-hook 0.4.4",
@@ -2751,6 +2753,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,6 +3587,12 @@ dependencies = [
  "walkdir",
  "yaml-rust",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ flamegraph = ["std", "dep:env_logger", "dep:inferno", "miden-debug-engine/tui"]
 tui = ["std", "flamegraph", "dep:crossterm", "dep:env_logger", "dep:ratatui", "dep:tui-input", "dep:signal-hook", "dep:syntect", "miden-debug-engine/tui"]
 repl = ["std", "dep:env_logger", "dep:rustyline", "miden-debug-engine/tui"]
 dap = ["miden-debug-engine/dap"]
+python = ["repl", "dep:pyo3"]
 std = ["clap/std", "clap/env", "compact_str/std", "miden-assembly-syntax/std", "miden-debug-engine/std"]
 proptest = ["miden-debug-engine/proptest"]
 
@@ -115,6 +116,7 @@ miden-debug-types.workspace = true
 miden-mast-package.workspace = true
 miden-package-registry.workspace = true
 miden-processor.workspace = true
+pyo3 = { version = "0.28.3", optional = true, features = ["auto-initialize"] }
 ratatui = { version = "0.30.0", optional = true }
 signal-hook = { version = "0.4.4", optional = true }
 syntect = { version = "5.2.0", optional = true, default-features = false, features = [
@@ -130,3 +132,6 @@ rustyline = { version = "18.0", optional = true }
 tokio = { version = "1.39.2", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tokio-util = "0.7.11"
 futures = "0.3.30"
+
+[build-dependencies]
+pyo3-build-config = { version = "0.28.3", features = ["resolve-config"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,119 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    println!("cargo:rerun-if-env-changed=PYO3_CONFIG_FILE");
+    println!("cargo:rerun-if-env-changed=PYO3_NO_PYTHON");
+
+    if env::var_os("CARGO_FEATURE_PYTHON").is_none() {
+        return;
+    }
+
+    pyo3_build_config::use_pyo3_cfgs();
+    pyo3_build_config::add_libpython_rpath_link_args();
+    pyo3_build_config::add_python_framework_link_args();
+
+    validate_python();
+}
+
+fn validate_python() {
+    let config = pyo3_build_config::get();
+
+    if config.implementation != pyo3_build_config::PythonImplementation::CPython {
+        panic!(
+            "miden-debug Python scripting embeds CPython, but PyO3 selected {} {}. Set \
+             PYO3_PYTHON to a CPython executable, or disable the `python` feature.",
+            config.implementation, config.version
+        );
+    }
+
+    if !config.shared {
+        panic!(
+            "miden-debug Python scripting requires a shared libpython, but PyO3 selected a static \
+             Python {} configuration. Set PYO3_PYTHON to an interpreter with a shared libpython, \
+             or provide PYO3_CONFIG_FILE with shared=true.",
+            config.version
+        );
+    }
+
+    if let Some(executable) = config.executable.as_deref() {
+        validate_python_executable(executable, &config.version.to_string());
+    } else {
+        println!(
+            "cargo:warning=Python scripting is using PYO3_CONFIG_FILE/cross-compile metadata; no \
+             host Python executable was available for an import smoke test"
+        );
+    }
+
+    match (config.python_framework_prefix.as_deref(), config.lib_dir.as_deref()) {
+        (Some(prefix), _) => validate_framework_prefix(prefix),
+        (None, Some(lib_dir)) => validate_lib_dir(lib_dir),
+        (None, None) => panic!(
+            "miden-debug Python scripting requires a Python library directory or framework \
+             prefix, but PyO3 did not report one. Set PYO3_PYTHON or PYO3_CONFIG_FILE to a \
+             complete Python development installation."
+        ),
+    }
+}
+
+fn validate_python_executable(executable: &str, expected_version: &str) {
+    let output = Command::new(executable)
+        .arg("-c")
+        .arg(
+            "import ctypes, sys; version=f'{sys.version_info[0]}.{sys.version_info[1]}'; assert \
+             version == __import__('os').environ['MIDEN_DEBUG_EXPECTED_PYTHON_VERSION']; \
+             ctypes.pythonapi.Py_IsInitialized",
+        )
+        .env("MIDEN_DEBUG_EXPECTED_PYTHON_VERSION", expected_version)
+        .output()
+        .unwrap_or_else(|err| {
+            panic!("failed to execute Python interpreter `{executable}` selected by PyO3: {err}")
+        });
+
+    if !output.status.success() {
+        panic!(
+            "Python interpreter `{}` selected by PyO3 failed the embed smoke \
+             test.\nstdout:\n{}\nstderr:\n{}",
+            executable,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+fn validate_framework_prefix(prefix: &str) {
+    let prefix = Path::new(prefix);
+    if !prefix.exists() {
+        panic!(
+            "PyO3 selected Python framework prefix `{}`, but it does not exist. Set PYO3_PYTHON \
+             to a usable framework Python.",
+            prefix.display()
+        );
+    }
+
+    let framework = prefix.join("Python3.framework");
+    if framework.exists() {
+        return;
+    }
+
+    println!(
+        "cargo:warning=PyO3 selected Python framework prefix `{}`, but Python3.framework was not \
+         found directly under it; continuing because custom framework layouts are possible",
+        prefix.display()
+    );
+}
+
+fn validate_lib_dir(lib_dir: &str) {
+    let lib_dir = PathBuf::from(lib_dir);
+    if !lib_dir.exists() {
+        panic!(
+            "PyO3 selected Python library directory `{}`, but it does not exist. Set PYO3_PYTHON \
+             to a Python installation with development libraries.",
+            lib_dir.display()
+        );
+    }
+}

--- a/docs/external/src/python-scripting.md
+++ b/docs/external/src/python-scripting.md
@@ -1,0 +1,98 @@
+---
+title: Python Scripting
+sidebar_position: 7
+---
+
+# Python scripting
+
+Python scripting is available only when `miden-debug` is built with the
+`python` feature:
+
+```bash
+cargo build --features "repl,python" --bin miden-debug
+```
+
+Python scripts are arbitrary local code. Only run scripts you trust. The
+debugger auto-loads `.miden-debug.py` from the debugger working directory when
+the file exists; pass `--no-user-python-init` to disable that.
+
+## REPL commands
+
+```text
+script <code>                         # execute one Python snippet
+script                                # enter Python's interactive console
+command script import ./file.py       # import a Python file
+command script add NAME -f mod.func   # register a Python-backed command
+command script list
+command script delete NAME
+breakpoint command add ID -f mod.func # register a breakpoint callback
+breakpoint command list
+breakpoint command delete [ID]
+```
+
+`script <expr>` prints the expression value when it is not `None`:
+
+```text
+[cycle 0 STOP] > script x = 1
+[cycle 0 STOP] > script x + 1
+2
+```
+
+The embedded module is named `miden_debugger` and provides convenience globals:
+
+```python
+import miden_debugger as miden
+
+miden.debugger.get_cycle()
+miden.process.stack()
+miden.frame.variables()
+```
+
+## Module initializer
+
+Imported modules may define:
+
+```python
+def __miden_init_module(debugger, internal_dict):
+    internal_dict["loaded"] = True
+```
+
+`internal_dict` persists for the debugger session and is shared with commands
+and breakpoint callbacks.
+
+## Custom command callback
+
+```python
+def cycle(debugger, command, exe_ctx, result, internal_dict):
+    print(debugger.get_cycle(), file=result)
+```
+
+Register it from the REPL:
+
+```text
+command script import examples/python/cycle.py
+command script add py-cycle -f cycle.cycle
+py-cycle
+```
+
+## Breakpoint callback
+
+Breakpoint callbacks receive `(frame, breakpoint, internal_dict)`.
+
+Return `False` to continue execution without reporting the breakpoint stop.
+Return `True`, `None`, or any truthy value to stop normally.
+
+```python
+def stop_when_iter_is_5(frame, breakpoint, internal_dict):
+    value = frame.variables().get("iter")
+    return value is not None and value.value == 5
+```
+
+Register it:
+
+```text
+b in *entrypoint*
+command script import examples/python/watch_var.py
+breakpoint command add 0 -f watch_var.stop_when_iter_is_5
+c
+```

--- a/examples/python/cycle.py
+++ b/examples/python/cycle.py
@@ -1,0 +1,6 @@
+def cycle(debugger, command, exe_ctx, result, internal_dict):
+    print(debugger.get_cycle(), file=result)
+
+
+def __miden_init_module(debugger, internal_dict):
+    internal_dict["cycle_example_loaded"] = True

--- a/examples/python/dump_stack.py
+++ b/examples/python/dump_stack.py
@@ -1,0 +1,4 @@
+def dump_stack(debugger, command, exe_ctx, result, internal_dict):
+    stack = exe_ctx.process().stack()
+    for index, value in enumerate(stack):
+        print(f"{index:02}: {value}", file=result)

--- a/examples/python/watch_var.py
+++ b/examples/python/watch_var.py
@@ -1,0 +1,3 @@
+def stop_when_iter_is_5(frame, breakpoint, internal_dict):
+    value = frame.variables().get("iter")
+    return value is not None and value.value == 5

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,10 @@ pub struct DebuggerConfig {
         )
     )]
     pub commands: Option<PathBuf>,
+    /// Do not auto-load the project-local `.miden-debug.py` file.
+    #[cfg(feature = "python")]
+    #[cfg_attr(feature = "python", arg(long, help_heading = "Scripting"))]
+    pub no_user_python_init: bool,
 }
 
 /// ColorChoice represents the color preferences of an end user.

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -211,6 +211,8 @@ impl FlamegraphArgs {
             link_libraries: self.link_libraries,
             repl: false,
             commands: None,
+            #[cfg(feature = "python")]
+            no_user_python_init: true,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ mod ui;
 
 #[cfg(feature = "repl")]
 mod repl;
+#[cfg(feature = "repl")]
+pub mod script;
 
 #[cfg(feature = "dap")]
 pub use self::dap_server::run as run_dap_server;

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -299,7 +299,7 @@ fn read_package_unchecked<R: ByteReader>(source: &mut R) -> Result<Package, Dese
     })
 }
 
-#[cfg(any(feature = "tui", feature = "flamegraph"))]
+#[cfg(any(feature = "tui", feature = "repl", feature = "flamegraph"))]
 impl clap::builder::ValueParserFactory for LinkLibrary {
     type Parser = LinkLibraryParser;
 
@@ -308,12 +308,12 @@ impl clap::builder::ValueParserFactory for LinkLibrary {
     }
 }
 
-#[cfg(any(feature = "tui", feature = "flamegraph"))]
+#[cfg(any(feature = "tui", feature = "repl", feature = "flamegraph"))]
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct LinkLibraryParser;
 
-#[cfg(any(feature = "tui", feature = "flamegraph"))]
+#[cfg(any(feature = "tui", feature = "repl", feature = "flamegraph"))]
 impl clap::builder::TypedValueParser for LinkLibraryParser {
     type Value = LinkLibrary;
 

--- a/src/repl/commands.rs
+++ b/src/repl/commands.rs
@@ -115,6 +115,58 @@ impl FromStr for ReplCommand {
 impl ReplCommand {
     /// Returns the help text for all commands.
     pub fn help_text() -> &'static str {
+        #[cfg(feature = "python")]
+        {
+            r#"Available commands:
+
+Execution:
+  s, step [N]        Execute one (or N) VM cycle(s)
+  n, next            Execute until next instruction boundary
+  nl, next-line      Execute until next source line
+  c, continue        Run until breakpoint or end
+  e, finish          Run until current function returns
+  reload             Restart program execution
+
+Breakpoints:
+  b, break <spec>    Set a breakpoint
+                     Specs: at <cycle>, after <N>, in <proc>, <file>:<line>, <file>
+  bp, breakpoints    List all breakpoints
+  d, delete [id]     Delete breakpoint by id, or all if no id given
+
+Inspection:
+  stack              Show operand stack
+  mem <addr> [type]  Show memory at address (e.g., mem 0x100 u32)
+  locals             Show local variables
+  vars [all]         Show source variables; include compiler locals with `all`
+  where              Show current source location
+  l, list            Show recent instructions
+  bt, backtrace      Show call stack
+
+Scripting:
+  script <code>      Execute one Python snippet
+  script             Enter the embedded Python console
+  command script import <file.py>
+                     Import a Python module and run its initializer if present
+  command script add <name> -f module.function
+                     Register a Python-backed debugger command
+  command script list
+                     List Python-backed debugger commands
+  command script delete <name>
+                     Delete a Python-backed debugger command
+  breakpoint command add <id> -f module.function
+                     Register a Python callback for a breakpoint
+  breakpoint command list
+                     List Python breakpoint callbacks
+  breakpoint command delete [id]
+                     Delete one or all Python breakpoint callbacks
+
+Other:
+  h, help            Show this help
+  q, quit            Exit debugger
+"#
+        }
+
+        #[cfg(not(feature = "python"))]
         r#"Available commands:
 
 Execution:

--- a/src/repl/engine.rs
+++ b/src/repl/engine.rs
@@ -33,9 +33,24 @@ impl ReplEngine {
         })
     }
 
+    /// Create an engine from an already constructed debugger state.
+    pub(crate) fn from_state(state: State) -> Self {
+        Self { state }
+    }
+
     /// Create an engine from a debugger configuration.
     pub fn from_config(config: Box<DebuggerConfig>) -> Result<Self, Report> {
         Self::new(config)
+    }
+
+    /// Borrow the current debugger state.
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+
+    /// Mutably borrow the current debugger state.
+    pub fn state_mut(&mut self) -> &mut State {
+        &mut self.state
     }
 
     /// Render the prompt for the current execution state.
@@ -349,7 +364,7 @@ impl ReplEngine {
     }
 }
 
-fn format_bp_type(ty: &BreakpointType) -> String {
+pub(crate) fn format_bp_type(ty: &BreakpointType) -> String {
     match ty {
         BreakpointType::Step => "next cycle".into(),
         BreakpointType::StepN(n) => format!("after {} cycles", n),

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,5 +1,7 @@
 mod commands;
-mod engine;
+pub(crate) mod engine;
+#[cfg(feature = "python")]
+mod python;
 mod script;
 mod session;
 

--- a/src/repl/python.rs
+++ b/src/repl/python.rs
@@ -1,0 +1,477 @@
+use std::{io::Write, path::PathBuf};
+
+use super::engine::Outcome;
+use crate::{
+    config::DebuggerConfig,
+    script::{PythonScriptSession, ScriptDebugger},
+};
+
+pub(crate) fn project_init_file(config: &DebuggerConfig) -> Option<PathBuf> {
+    if config.no_user_python_init {
+        return None;
+    }
+
+    let path = config.working_dir().join(".miden-debug.py");
+    path.try_exists().ok().is_some_and(|exists| exists).then_some(path)
+}
+
+pub(crate) fn execute_line(
+    debugger: &ScriptDebugger,
+    python: &mut PythonScriptSession,
+    line: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, String> {
+    match parse_script_command(line) {
+        Some(ScriptCommand::Snippet(code)) => {
+            let output = python.execute_snippet(code)?;
+            write!(out, "{output}").map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::InteractiveConsole) => {
+            python.interact()?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::Import(path)) => {
+            python.import_file(path)?;
+            writeln!(out, "Imported Python script: {path}")
+                .map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::AddCommand { name, function }) => {
+            python.add_custom_command(name, function)?;
+            writeln!(out, "Added Python command: {name}")
+                .map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::ListCommands) => {
+            let commands = python.custom_commands();
+            if commands.is_empty() {
+                writeln!(out, "No Python commands registered")
+                    .map_err(|err| format!("failed to write output: {err}"))?;
+            } else {
+                writeln!(out, "Python commands:")
+                    .map_err(|err| format!("failed to write output: {err}"))?;
+                for command in commands {
+                    writeln!(out, "  {command}")
+                        .map_err(|err| format!("failed to write output: {err}"))?;
+                }
+            }
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::DeleteCommand(name)) => {
+            python.delete_custom_command(name)?;
+            writeln!(out, "Deleted Python command: {name}")
+                .map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::AddBreakpointCallback { id, function }) => {
+            python.add_breakpoint_callback(id, function)?;
+            writeln!(out, "Added Python callback for breakpoint {id}")
+                .map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::ListBreakpointCallbacks) => {
+            let callbacks = python.breakpoint_callbacks();
+            if callbacks.is_empty() {
+                writeln!(out, "No Python breakpoint callbacks registered")
+                    .map_err(|err| format!("failed to write output: {err}"))?;
+            } else {
+                writeln!(out, "Python breakpoint callbacks:")
+                    .map_err(|err| format!("failed to write output: {err}"))?;
+                for id in callbacks {
+                    writeln!(out, "  breakpoint {id}")
+                        .map_err(|err| format!("failed to write output: {err}"))?;
+                }
+            }
+            Ok(Outcome::Continue)
+        }
+        Some(ScriptCommand::DeleteBreakpointCallback(id)) => {
+            python.delete_breakpoint_callback(id)?;
+            match id {
+                Some(id) => writeln!(out, "Deleted Python callback for breakpoint {id}"),
+                None => writeln!(out, "Deleted all Python breakpoint callbacks"),
+            }
+            .map_err(|err| format!("failed to write output: {err}"))?;
+            Ok(Outcome::Continue)
+        }
+        None if is_resume_command(line) => execute_resume_command(debugger, python, line, out),
+        None => match debugger.execute_repl_line(line, out) {
+            Err(err) if is_unknown_command_error(line, &err) => {
+                let (name, args) = split_command(line);
+                match python.execute_custom_command(name, args)? {
+                    Some(output) => {
+                        write!(out, "{output}")
+                            .map_err(|err| format!("failed to write output: {err}"))?;
+                        Ok(Outcome::Continue)
+                    }
+                    None => Err(err),
+                }
+            }
+            outcome => outcome,
+        },
+    }
+}
+
+enum ScriptCommand<'a> {
+    Snippet(&'a str),
+    InteractiveConsole,
+    Import(&'a str),
+    AddCommand { name: &'a str, function: &'a str },
+    ListCommands,
+    DeleteCommand(&'a str),
+    AddBreakpointCallback { id: u8, function: &'a str },
+    ListBreakpointCallbacks,
+    DeleteBreakpointCallback(Option<u8>),
+}
+
+fn parse_script_command(line: &str) -> Option<ScriptCommand<'_>> {
+    let line = line.trim();
+    if let Some(command) = parse_command_script_command(line) {
+        return Some(command);
+    }
+    if let Some(command) = parse_breakpoint_command(line) {
+        return Some(command);
+    }
+
+    if line == "script" {
+        return Some(ScriptCommand::InteractiveConsole);
+    }
+
+    let code = line.strip_prefix("script")?;
+    if code.chars().next().is_some_and(char::is_whitespace) {
+        let code = code.trim_start();
+        if code.is_empty() {
+            Some(ScriptCommand::InteractiveConsole)
+        } else {
+            Some(ScriptCommand::Snippet(code))
+        }
+    } else {
+        None
+    }
+}
+
+fn execute_resume_command(
+    debugger: &ScriptDebugger,
+    python: &mut PythonScriptSession,
+    line: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, String> {
+    let mut command = line.to_string();
+    loop {
+        let mut buffered_output = Vec::new();
+        let outcome = debugger.execute_repl_line(&command, &mut buffered_output)?;
+        if outcome == Outcome::Quit || debugger.terminated() {
+            out.write_all(&buffered_output)
+                .map_err(|err| format!("failed to write output: {err}"))?;
+            return Ok(outcome);
+        }
+
+        if python.should_continue_after_breakpoint_callbacks()? {
+            debugger.clear_hit_breakpoints();
+            command = "continue".into();
+            continue;
+        }
+
+        out.write_all(&buffered_output)
+            .map_err(|err| format!("failed to write output: {err}"))?;
+        return Ok(outcome);
+    }
+}
+
+fn parse_breakpoint_command(line: &str) -> Option<ScriptCommand<'_>> {
+    if let Some(rest) = line.strip_prefix("breakpoint command add")
+        && rest.chars().next().is_some_and(char::is_whitespace)
+        && let Some((id, function)) = parse_breakpoint_command_add_args(rest.trim_start())
+    {
+        return Some(ScriptCommand::AddBreakpointCallback { id, function });
+    }
+
+    if let Some(rest) = line.strip_prefix("breakpoint command list")
+        && rest.trim().is_empty()
+    {
+        return Some(ScriptCommand::ListBreakpointCallbacks);
+    }
+
+    if let Some(rest) = line.strip_prefix("breakpoint command delete") {
+        let rest = rest.trim();
+        if rest.is_empty() {
+            return Some(ScriptCommand::DeleteBreakpointCallback(None));
+        }
+        if let Ok(id) = rest.parse::<u8>() {
+            return Some(ScriptCommand::DeleteBreakpointCallback(Some(id)));
+        }
+    }
+
+    None
+}
+
+fn parse_breakpoint_command_add_args(args: &str) -> Option<(u8, &str)> {
+    let (id, rest) = split_command(args);
+    let id = id.parse::<u8>().ok()?;
+    let rest = rest.trim();
+    let function = rest.strip_prefix("-f")?.trim_start();
+    if function.is_empty() {
+        None
+    } else {
+        Some((id, function))
+    }
+}
+
+fn parse_command_script_command(line: &str) -> Option<ScriptCommand<'_>> {
+    if let Some(path) = line.strip_prefix("command script import")
+        && path.chars().next().is_some_and(char::is_whitespace)
+    {
+        let path = path.trim_start();
+        if !path.is_empty() {
+            return Some(ScriptCommand::Import(path));
+        }
+    }
+
+    if let Some(rest) = line.strip_prefix("command script list")
+        && rest.trim().is_empty()
+    {
+        return Some(ScriptCommand::ListCommands);
+    }
+
+    if let Some(name) = line.strip_prefix("command script delete")
+        && name.chars().next().is_some_and(char::is_whitespace)
+    {
+        let name = name.trim_start();
+        if !name.is_empty() {
+            return Some(ScriptCommand::DeleteCommand(name));
+        }
+    }
+
+    if let Some(rest) = line.strip_prefix("command script add")
+        && rest.chars().next().is_some_and(char::is_whitespace)
+        && let Some((name, function)) = parse_command_script_add_args(rest.trim_start())
+    {
+        return Some(ScriptCommand::AddCommand { name, function });
+    }
+
+    None
+}
+
+fn parse_command_script_add_args(args: &str) -> Option<(&str, &str)> {
+    let (name, rest) = split_command(args);
+    let rest = rest.trim();
+    let function = rest.strip_prefix("-f")?.trim_start();
+    if name.is_empty() || function.is_empty() {
+        None
+    } else {
+        Some((name, function))
+    }
+}
+
+fn split_command(line: &str) -> (&str, &str) {
+    match line.trim().split_once(char::is_whitespace) {
+        Some((name, args)) => (name, args.trim_start()),
+        None => (line.trim(), ""),
+    }
+}
+
+fn is_unknown_command_error(line: &str, err: &str) -> bool {
+    let (name, _) = split_command(line);
+    err == format!("unknown command: {name}")
+}
+
+fn is_resume_command(line: &str) -> bool {
+    let (name, _) = split_command(line);
+    matches!(
+        name,
+        "c" | "continue" | "n" | "next" | "nl" | "next-line" | "nextline" | "e" | "finish"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_core::Felt;
+
+    use super::*;
+
+    fn test_debugger() -> ScriptDebugger {
+        ScriptDebugger::from_masm_source(
+            r#"
+begin
+    push.3
+end
+"#,
+            Vec::<Felt>::new(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_script_commands_only() {
+        assert!(matches!(
+            parse_script_command("script"),
+            Some(ScriptCommand::InteractiveConsole)
+        ));
+        assert!(matches!(
+            parse_script_command("script 1 + 1"),
+            Some(ScriptCommand::Snippet("1 + 1"))
+        ));
+        assert!(matches!(
+            parse_script_command("command script import /tmp/demo.py"),
+            Some(ScriptCommand::Import("/tmp/demo.py"))
+        ));
+        assert!(parse_script_command("scripts").is_none());
+        assert!(parse_script_command("step").is_none());
+    }
+
+    #[test]
+    fn executes_script_snippets_through_repl_route() {
+        let _guard = crate::script::python::python_test_lock();
+        let debugger = test_debugger();
+        let mut python = PythonScriptSession::new(debugger.clone()).unwrap();
+        let mut output = Vec::new();
+
+        execute_line(&debugger, &mut python, "script x = 1", &mut output).unwrap();
+        execute_line(&debugger, &mut python, "script x + 1", &mut output).unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap(), "2\n");
+    }
+
+    #[test]
+    fn imports_script_and_runs_initializer() {
+        let _guard = crate::script::python::python_test_lock();
+        let debugger = test_debugger();
+        let mut python = PythonScriptSession::new(debugger.clone()).unwrap();
+        let temp_path = std::env::temp_dir().join(format!(
+            "miden-debug-python-import-{}-{}.py",
+            std::process::id(),
+            0
+        ));
+        std::fs::write(
+            &temp_path,
+            r#"
+def __miden_init_module(debugger, internal_dict):
+    internal_dict["loaded_cycle"] = debugger.get_cycle()
+"#,
+        )
+        .unwrap();
+
+        let mut output = Vec::new();
+        execute_line(
+            &debugger,
+            &mut python,
+            &format!("command script import {}", temp_path.display()),
+            &mut output,
+        )
+        .unwrap();
+        execute_line(&debugger, &mut python, "script internal_dict['loaded_cycle']", &mut output)
+            .unwrap();
+
+        let _ = std::fs::remove_file(&temp_path);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Imported Python script:"));
+        assert!(output.ends_with("0\n"));
+    }
+
+    #[test]
+    fn registers_and_executes_custom_python_command() {
+        let _guard = crate::script::python::python_test_lock();
+        let debugger = test_debugger();
+        let mut python = PythonScriptSession::new(debugger.clone()).unwrap();
+        let temp_path = std::env::temp_dir()
+            .join(format!("miden_debug_python_command_{}.py", std::process::id()));
+        std::fs::write(
+            &temp_path,
+            r#"
+def cycle(debugger, command, exe_ctx, result, internal_dict):
+    print(f"{debugger.get_cycle()}:{command}", file=result)
+"#,
+        )
+        .unwrap();
+
+        let mut output = Vec::new();
+        execute_line(
+            &debugger,
+            &mut python,
+            &format!("command script import {}", temp_path.display()),
+            &mut output,
+        )
+        .unwrap();
+        execute_line(
+            &debugger,
+            &mut python,
+            &format!(
+                "command script add py-cycle -f {}.cycle",
+                temp_path.file_stem().unwrap().to_str().unwrap()
+            ),
+            &mut output,
+        )
+        .unwrap();
+        execute_line(&debugger, &mut python, "py-cycle hello", &mut output).unwrap();
+        execute_line(&debugger, &mut python, "command script list", &mut output).unwrap();
+        execute_line(&debugger, &mut python, "command script delete py-cycle", &mut output)
+            .unwrap();
+
+        let _ = std::fs::remove_file(&temp_path);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Added Python command: py-cycle"));
+        assert!(output.contains("0:hello\n"));
+        assert!(output.contains("Python commands:\n  py-cycle\n"));
+        assert!(output.contains("Deleted Python command: py-cycle"));
+    }
+
+    #[test]
+    fn breakpoint_callback_false_continues_execution() {
+        let _guard = crate::script::python::python_test_lock();
+        let debugger = ScriptDebugger::from_masm_source(
+            r#"
+begin
+    push.1
+    drop
+    push.2
+    drop
+    push.3
+    drop
+end
+"#,
+            Vec::<Felt>::new(),
+        )
+        .unwrap();
+        let mut python = PythonScriptSession::new(debugger.clone()).unwrap();
+        let temp_path =
+            std::env::temp_dir().join(format!("miden_debug_bp_callback_{}.py", std::process::id()));
+        std::fs::write(
+            &temp_path,
+            r#"
+def never_stop(frame, breakpoint, internal_dict):
+    internal_dict["called"] = internal_dict.get("called", 0) + 1
+    return False
+"#,
+        )
+        .unwrap();
+
+        let mut output = Vec::new();
+        execute_line(&debugger, &mut python, "b after 1", &mut output).unwrap();
+        execute_line(
+            &debugger,
+            &mut python,
+            &format!("command script import {}", temp_path.display()),
+            &mut output,
+        )
+        .unwrap();
+        execute_line(
+            &debugger,
+            &mut python,
+            &format!(
+                "breakpoint command add 0 -f {}.never_stop",
+                temp_path.file_stem().unwrap().to_str().unwrap()
+            ),
+            &mut output,
+        )
+        .unwrap();
+        execute_line(&debugger, &mut python, "continue", &mut output).unwrap();
+        execute_line(&debugger, &mut python, "script internal_dict['called']", &mut output)
+            .unwrap();
+
+        let _ = std::fs::remove_file(&temp_path);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Added Python callback for breakpoint 0"), "output:\n{output}");
+        assert!(output.contains("Program terminated successfully"), "output:\n{output}");
+        assert!(output.ends_with("1\n"), "output:\n{output}");
+    }
+}

--- a/src/repl/script.rs
+++ b/src/repl/script.rs
@@ -2,8 +2,8 @@ use std::{io::Write, path::Path};
 
 use miden_assembly_syntax::diagnostics::Report;
 
-use super::engine::{Outcome, ReplEngine};
-use crate::config::DebuggerConfig;
+use super::engine::Outcome;
+use crate::{config::DebuggerConfig, script::ScriptDebugger};
 
 /// Run a script of debugger commands non-interactively, then return.
 ///
@@ -24,21 +24,64 @@ pub fn run_commands(config: Box<DebuggerConfig>, script_path: &Path) -> Result<(
         Report::msg(format!("failed to read command file {}: {e}", script_path.display()))
     })?;
 
-    let mut engine = ReplEngine::from_config(config)?;
+    #[cfg(feature = "python")]
+    let python_init_file = super::python::project_init_file(&config);
+    let debugger = ScriptDebugger::from_config(config)?;
+    #[cfg(feature = "python")]
+    let mut python = {
+        let python = crate::script::PythonScriptSession::new(debugger.clone())
+            .map_err(|e| Report::msg(format!("failed to initialize Python scripting: {e}")))?;
+        if let Some(path) = python_init_file {
+            python.import_file(&path).map_err(|e| {
+                Report::msg(format!("failed to load Python init file {}: {e}", path.display()))
+            })?;
+        }
+        python
+    };
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    run_lines(&mut engine, &script, &mut out);
+    #[cfg(feature = "python")]
+    run_lines(&debugger, Some(&mut python), &script, &mut out);
+    #[cfg(not(feature = "python"))]
+    run_lines(&debugger, &script, &mut out);
     Ok(())
 }
 
-fn run_lines(engine: &mut ReplEngine, script: &str, out: &mut dyn Write) {
+#[cfg(feature = "python")]
+fn run_lines(
+    debugger: &ScriptDebugger,
+    mut python: Option<&mut crate::script::PythonScriptSession>,
+    script: &str,
+    out: &mut dyn Write,
+) {
     for line in script.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
-        match engine.execute_line(line, out) {
+        let outcome = match python.as_deref_mut() {
+            Some(python) => super::python::execute_line(debugger, python, line, out),
+            None => debugger.execute_repl_line(line, out),
+        };
+
+        match outcome {
+            Ok(Outcome::Quit) => break,
+            Ok(Outcome::Continue) => {}
+            Err(e) => eprintln!("error: {e}"),
+        }
+    }
+}
+
+#[cfg(not(feature = "python"))]
+fn run_lines(debugger: &ScriptDebugger, script: &str, out: &mut dyn Write) {
+    for line in script.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        match debugger.execute_repl_line(line, out) {
             Ok(Outcome::Quit) => break,
             Ok(Outcome::Continue) => {}
             Err(e) => eprintln!("error: {e}"),

--- a/src/repl/session.rs
+++ b/src/repl/session.rs
@@ -1,8 +1,8 @@
 use miden_assembly_syntax::diagnostics::Report;
 use rustyline::{DefaultEditor, error::ReadlineError};
 
-use super::engine::{Outcome, ReplEngine};
-use crate::config::DebuggerConfig;
+use super::engine::Outcome;
+use crate::{config::DebuggerConfig, script::ScriptDebugger};
 
 /// Interactive REPL session for the debugger.
 ///
@@ -11,18 +11,38 @@ use crate::config::DebuggerConfig;
 /// output formatting lives in [`ReplEngine`], so it can be reused by the
 /// scriptable test harness without a terminal.
 pub struct ReplSession {
-    engine: ReplEngine,
+    debugger: ScriptDebugger,
+    #[cfg(feature = "python")]
+    python: crate::script::PythonScriptSession,
     editor: DefaultEditor,
 }
 
 impl ReplSession {
     /// Create a new REPL session from the given config.
     pub fn new(config: Box<DebuggerConfig>) -> Result<Self, Report> {
-        let engine = ReplEngine::new(config)?;
+        #[cfg(feature = "python")]
+        let python_init_file = super::python::project_init_file(&config);
+        let debugger = ScriptDebugger::new(config)?;
+        #[cfg(feature = "python")]
+        let python = {
+            let python = crate::script::PythonScriptSession::new(debugger.clone())
+                .map_err(|e| Report::msg(format!("failed to initialize Python scripting: {e}")))?;
+            if let Some(path) = python_init_file {
+                python.import_file(&path).map_err(|e| {
+                    Report::msg(format!("failed to load Python init file {}: {e}", path.display()))
+                })?;
+            }
+            python
+        };
         let editor = DefaultEditor::new()
             .map_err(|e| Report::msg(format!("failed to create editor: {e}")))?;
 
-        Ok(Self { engine, editor })
+        Ok(Self {
+            debugger,
+            #[cfg(feature = "python")]
+            python,
+            editor,
+        })
     }
 
     /// Run the main REPL loop.
@@ -30,10 +50,10 @@ impl ReplSession {
         self.print_welcome();
 
         let mut stdout = std::io::stdout();
-        self.engine.print_location(&mut stdout);
+        self.debugger.print_location(&mut stdout);
 
         loop {
-            let prompt = self.engine.make_prompt(true);
+            let prompt = self.debugger.make_prompt(true);
             match self.editor.readline(&prompt) {
                 Ok(line) => {
                     let line = line.trim();
@@ -45,7 +65,17 @@ impl ReplSession {
                     let _ = self.editor.add_history_entry(line);
 
                     // Parse and execute command
-                    match self.engine.execute_line(line, &mut stdout) {
+                    #[cfg(feature = "python")]
+                    let outcome = super::python::execute_line(
+                        &self.debugger,
+                        &mut self.python,
+                        line,
+                        &mut stdout,
+                    );
+                    #[cfg(not(feature = "python"))]
+                    let outcome = self.debugger.execute_repl_line(line, &mut stdout);
+
+                    match outcome {
                         Ok(Outcome::Quit) => {
                             println!("\x1b[36mGoodbye!\x1b[0m");
                             break;

--- a/src/script/api.rs
+++ b/src/script/api.rs
@@ -1,0 +1,355 @@
+use std::{cell::RefCell, io::Write, rc::Rc, str::FromStr};
+
+use miden_assembly_syntax::diagnostics::Report;
+
+use crate::{
+    DebuggerConfig,
+    debug::{Breakpoint, BreakpointType, ReadMemoryExpr},
+    repl::engine::{Outcome, ReplEngine, format_bp_type},
+};
+
+/// Source location snapshot exposed to scripting frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptSourceLocation {
+    pub path: String,
+    pub line: u32,
+    pub column: u32,
+}
+
+/// Variable snapshot exposed to scripting frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptValue {
+    pub name: String,
+    pub value: Option<u64>,
+    pub location: String,
+    pub source: Option<ScriptSourceLocation>,
+}
+
+/// Current frame snapshot exposed to scripting frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptFrame {
+    pub function_name: Option<String>,
+    pub source_location: Option<ScriptSourceLocation>,
+    pub variables: Vec<ScriptValue>,
+}
+
+/// Breakpoint snapshot exposed to scripting frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptBreakpoint {
+    pub id: u8,
+    pub spec: String,
+    pub internal: bool,
+    pub one_shot: bool,
+}
+
+/// Execution context snapshot exposed to scripting callbacks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptExecutionContext {
+    pub cycle: usize,
+    pub stopped: bool,
+    pub terminated: bool,
+    pub frame: ScriptFrame,
+}
+
+/// Stable facade used by debugger scripting integrations.
+#[derive(Clone)]
+pub struct ScriptDebugger {
+    engine: Rc<RefCell<ReplEngine>>,
+}
+
+impl ScriptDebugger {
+    /// Create a script debugger from the same configuration used by the REPL.
+    pub fn new(config: Box<DebuggerConfig>) -> Result<Self, Report> {
+        Self::from_config(config)
+    }
+
+    /// Create a script debugger from a debugger configuration.
+    pub fn from_config(config: Box<DebuggerConfig>) -> Result<Self, Report> {
+        Ok(Self {
+            engine: Rc::new(RefCell::new(ReplEngine::from_config(config)?)),
+        })
+    }
+
+    /// Create a script debugger from inline MASM source.
+    ///
+    /// This is useful for tests and small programmatic debugging harnesses.
+    pub fn from_masm_source(
+        source: &str,
+        args: Vec<crate::processor::Felt>,
+    ) -> Result<Self, Report> {
+        let state = crate::ui::state::State::from_masm_source(source, args)?;
+        Ok(Self {
+            engine: Rc::new(RefCell::new(ReplEngine::from_state(state))),
+        })
+    }
+
+    /// Render the normal debugger prompt.
+    pub(crate) fn make_prompt(&self, color: bool) -> String {
+        self.engine.borrow().make_prompt(color)
+    }
+
+    /// Print the current source location / procedure.
+    pub(crate) fn print_location(&self, out: &mut dyn Write) {
+        self.engine.borrow().print_location(out);
+    }
+
+    /// Execute a REPL command line while preserving the raw REPL outcome.
+    pub(crate) fn execute_repl_line(
+        &self,
+        line: &str,
+        out: &mut dyn Write,
+    ) -> Result<Outcome, String> {
+        self.engine.borrow_mut().execute_line(line, out)
+    }
+
+    /// Execute a debugger command and capture its textual output.
+    pub fn handle_command(&self, command: &str) -> Result<String, String> {
+        let mut output = Vec::new();
+        match self.engine.borrow_mut().execute_line(command, &mut output)? {
+            Outcome::Continue => {}
+            Outcome::Quit => return Err("quit requested".into()),
+        }
+
+        String::from_utf8(output).map_err(|err| format!("command output was not UTF-8: {err}"))
+    }
+
+    /// Current VM cycle.
+    pub fn cycle(&self) -> usize {
+        self.engine.borrow().state().executor().cycle
+    }
+
+    /// Whether execution is currently stopped at a debugger stop point.
+    pub fn stopped(&self) -> bool {
+        self.engine.borrow().state().stopped
+    }
+
+    /// Whether the debuggee has terminated.
+    pub fn terminated(&self) -> bool {
+        self.engine.borrow().state().executor().stopped
+    }
+
+    /// Current operand stack snapshot, in debugger display order.
+    pub fn stack(&self) -> Vec<u64> {
+        self.engine
+            .borrow()
+            .state()
+            .executor()
+            .current_stack
+            .iter()
+            .map(|felt| felt.as_canonical_u64())
+            .collect()
+    }
+
+    /// Source path prefix mappings currently configured for this debugger.
+    pub fn source_path_prefixes(&self) -> Vec<String> {
+        self.engine.borrow().state().source_path_prefixes()
+    }
+
+    /// Current frame snapshot.
+    pub fn frame(&self) -> ScriptFrame {
+        self.frame_with_variables(false)
+    }
+
+    /// Current frame snapshot with either source-visible or all debug variables.
+    pub fn frame_with_variables(&self, show_all: bool) -> ScriptFrame {
+        let engine = self.engine.borrow();
+        let state = engine.state();
+        let source_location = state.current_display_location().map(|loc| ScriptSourceLocation {
+            path: loc.source_file.uri().as_str().to_string(),
+            line: loc.line,
+            column: loc.col,
+        });
+        let function_name = state.current_procedure().map(|name| name.to_string());
+        let variables = state
+            .current_variables(show_all)
+            .into_iter()
+            .map(|variable| ScriptValue {
+                name: variable.name,
+                value: variable.value.map(|felt| felt.as_canonical_u64()),
+                location: variable.location,
+                source: variable.source.map(|source| ScriptSourceLocation {
+                    path: source.path,
+                    line: source.line,
+                    column: source.column,
+                }),
+            })
+            .collect();
+
+        ScriptFrame {
+            function_name,
+            source_location,
+            variables,
+        }
+    }
+
+    /// Current execution context snapshot.
+    pub fn execution_context(&self) -> ScriptExecutionContext {
+        ScriptExecutionContext {
+            cycle: self.cycle(),
+            stopped: self.stopped(),
+            terminated: self.terminated(),
+            frame: self.frame(),
+        }
+    }
+
+    /// Current user-visible breakpoints.
+    pub fn breakpoints(&self) -> Vec<ScriptBreakpoint> {
+        self.engine
+            .borrow()
+            .state()
+            .breakpoints
+            .iter()
+            .filter(|bp| !bp.is_internal())
+            .map(script_breakpoint_from)
+            .collect()
+    }
+
+    /// Breakpoints hit at the current stop.
+    pub fn hit_breakpoints(&self) -> Vec<ScriptBreakpoint> {
+        self.engine
+            .borrow()
+            .state()
+            .breakpoints_hit
+            .iter()
+            .filter(|bp| !bp.is_internal())
+            .map(script_breakpoint_from)
+            .collect()
+    }
+
+    /// Clear the current hit-breakpoint list.
+    pub fn clear_hit_breakpoints(&self) {
+        self.engine.borrow_mut().state_mut().breakpoints_hit.clear();
+    }
+
+    /// Set a breakpoint from the normal debugger breakpoint grammar.
+    pub fn set_breakpoint(&self, spec: &str) -> Result<ScriptBreakpoint, String> {
+        let ty = BreakpointType::from_str(spec)?;
+        let mut engine = self.engine.borrow_mut();
+        engine.state_mut().create_breakpoint(ty);
+        let bp = engine
+            .state()
+            .breakpoints
+            .last()
+            .ok_or_else(|| "breakpoint was not created".to_string())?;
+        Ok(script_breakpoint_from(bp))
+    }
+
+    /// Delete one breakpoint by id, or all user breakpoints if `id` is `None`.
+    pub fn delete_breakpoint(&self, id: Option<u8>) -> Result<(), String> {
+        let mut engine = self.engine.borrow_mut();
+        let state = engine.state_mut();
+        match id {
+            Some(id) => {
+                let before = state.breakpoints.len();
+                state.breakpoints.retain(|bp| bp.id != id);
+                if state.breakpoints.len() == before {
+                    return Err(format!("no breakpoint with id {id}"));
+                }
+            }
+            None => {
+                state.breakpoints.retain(|bp| bp.is_internal());
+            }
+        }
+        Ok(())
+    }
+
+    /// Read memory using the debugger memory expression grammar.
+    pub fn read_memory(&self, expression: &str) -> Result<String, String> {
+        let expression = expression.parse::<ReadMemoryExpr>()?;
+        self.engine.borrow_mut().state_mut().read_memory(&expression)
+    }
+
+    /// Step one or more VM cycles.
+    pub fn step(&self, count: usize) -> Result<String, String> {
+        if count <= 1 {
+            self.handle_command("step")
+        } else {
+            self.handle_command(&format!("step {count}"))
+        }
+    }
+
+    /// Step to the next instruction boundary.
+    pub fn next(&self) -> Result<String, String> {
+        self.handle_command("next")
+    }
+
+    /// Step to the next source line.
+    pub fn next_line(&self) -> Result<String, String> {
+        self.handle_command("next-line")
+    }
+
+    /// Continue execution until the next breakpoint or termination.
+    pub fn continue_(&self) -> Result<String, String> {
+        self.handle_command("continue")
+    }
+
+    /// Continue execution until the current frame returns.
+    pub fn finish(&self) -> Result<String, String> {
+        self.handle_command("finish")
+    }
+
+    /// Reload the debuggee.
+    pub fn reload(&self) -> Result<String, String> {
+        self.handle_command("reload")
+    }
+}
+
+fn script_breakpoint_from(bp: &Breakpoint) -> ScriptBreakpoint {
+    ScriptBreakpoint {
+        id: bp.id,
+        spec: format_bp_type(&bp.ty),
+        internal: bp.is_internal(),
+        one_shot: bp.is_one_shot(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_core::Felt;
+
+    use super::*;
+
+    #[test]
+    fn script_debugger_executes_commands_and_exposes_state() {
+        let debugger = ScriptDebugger::from_masm_source(
+            r#"
+begin
+    push.3
+    push.4
+    add
+end
+"#,
+            Vec::<Felt>::new(),
+        )
+        .unwrap();
+
+        assert_eq!(debugger.cycle(), 0);
+
+        let output = debugger.handle_command("step").unwrap();
+        assert!(output.contains("in") || output.is_empty(), "unexpected output: {output}");
+        assert_eq!(debugger.cycle(), 1);
+
+        let stack_output = debugger.handle_command("stack").unwrap();
+        assert!(stack_output.contains("Operand Stack"));
+    }
+
+    #[test]
+    fn script_debugger_can_manage_breakpoints() {
+        let debugger = ScriptDebugger::from_masm_source(
+            r#"
+begin
+    push.3
+end
+"#,
+            Vec::<Felt>::new(),
+        )
+        .unwrap();
+
+        let bp = debugger.set_breakpoint("after 1").unwrap();
+        assert_eq!(bp.id, 0);
+        assert_eq!(debugger.breakpoints().len(), 1);
+
+        debugger.delete_breakpoint(Some(bp.id)).unwrap();
+        assert!(debugger.breakpoints().is_empty());
+    }
+}

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,0 +1,17 @@
+//! Script-facing debugger facade.
+//!
+//! This module intentionally exposes a small, stable object model over the
+//! debugger rather than binding directly to the TUI/REPL state internals. Python
+//! scripting can wrap these types later without coupling Python users to private
+//! Rust implementation details.
+
+mod api;
+#[cfg(feature = "python")]
+pub mod python;
+
+pub use self::api::{
+    ScriptBreakpoint, ScriptDebugger, ScriptExecutionContext, ScriptFrame, ScriptSourceLocation,
+    ScriptValue,
+};
+#[cfg(feature = "python")]
+pub use self::python::PythonScriptSession;

--- a/src/script/python.rs
+++ b/src/script/python.rs
@@ -1,0 +1,918 @@
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, hash_map::DefaultHasher},
+    ffi::CString,
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use pyo3::{
+    exceptions::{PyKeyError, PyRuntimeError, PySyntaxError},
+    prelude::*,
+    types::{PyDict, PyModule},
+};
+
+use super::{ScriptBreakpoint, ScriptDebugger, ScriptSourceLocation, ScriptValue};
+
+type SharedDebugger = Rc<RefCell<ScriptDebugger>>;
+
+#[cfg(test)]
+pub(crate) fn python_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(Mutex::default)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Embedded Python scripting session.
+///
+/// The session owns the current debugger handle plus a persistent globals
+/// dictionary. REPL integration can execute snippets against that dictionary so
+/// variables, imports, and registered callbacks persist across `script`
+/// commands.
+pub struct PythonScriptSession {
+    debugger: SharedDebugger,
+    globals: Py<PyDict>,
+    internal_dict: Py<PyDict>,
+    modules: RefCell<Vec<Py<PyModule>>>,
+    custom_commands: RefCell<BTreeMap<String, Py<PyAny>>>,
+    breakpoint_callbacks: RefCell<BTreeMap<u8, Py<PyAny>>>,
+}
+
+impl PythonScriptSession {
+    /// Create a Python scripting session over an existing script debugger.
+    pub fn new(debugger: ScriptDebugger) -> PyResult<Self> {
+        Python::attach(|py| {
+            let debugger = Rc::new(RefCell::new(debugger));
+            let module = create_miden_debugger_module(py, debugger.clone())?;
+            let globals = PyDict::new(py);
+            let internal_dict = PyDict::new(py);
+            let builtins = py.import("builtins")?;
+            globals.set_item("__builtins__", builtins)?;
+            globals.set_item("miden_debugger", module.clone())?;
+            globals.set_item("internal_dict", internal_dict.clone())?;
+            globals.set_item("debugger", module.getattr("debugger")?)?;
+            globals.set_item("target", module.getattr("target")?)?;
+            globals.set_item("process", module.getattr("process")?)?;
+            globals.set_item("thread", module.getattr("thread")?)?;
+            globals.set_item("frame", module.getattr("frame")?)?;
+
+            Ok(Self {
+                debugger,
+                globals: globals.unbind(),
+                internal_dict: internal_dict.unbind(),
+                modules: RefCell::default(),
+                custom_commands: RefCell::default(),
+                breakpoint_callbacks: RefCell::default(),
+            })
+        })
+    }
+
+    /// Return a Python wrapper around the current debugger.
+    pub fn debugger(&self) -> PyDebugger {
+        PyDebugger::new(self.debugger.clone())
+    }
+
+    /// Access the persistent Python globals dictionary for this session.
+    pub fn with_globals<R>(
+        &self,
+        py: Python<'_>,
+        f: impl FnOnce(&Bound<'_, PyDict>) -> PyResult<R>,
+    ) -> PyResult<R> {
+        f(self.globals.bind(py))
+    }
+
+    /// Execute one Python snippet in this session's persistent globals.
+    ///
+    /// Expressions print their `repr()` when they evaluate to a non-`None`
+    /// value. Statements are executed with no synthetic output.
+    pub fn execute_snippet(&self, code: &str) -> Result<String, String> {
+        Python::attach(|py| {
+            self.with_globals(py, |globals| {
+                let code = CString::new(code)
+                    .map_err(|_| PyRuntimeError::new_err("Python code contains a NUL byte"))?;
+
+                match py.eval(code.as_c_str(), Some(globals), Some(globals)) {
+                    Ok(value) if value.is_none() => Ok(String::new()),
+                    Ok(value) => Ok(format!("{}\n", value.repr()?.to_str()?)),
+                    Err(err) if err.is_instance_of::<PySyntaxError>(py) => {
+                        py.run(code.as_c_str(), Some(globals), Some(globals))?;
+                        Ok(String::new())
+                    }
+                    Err(err) => Err(err),
+                }
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Enter Python's standard interactive console with this session's globals.
+    pub fn interact(&self) -> Result<(), String> {
+        Python::attach(|py| {
+            self.with_globals(py, |globals| {
+                let code = py.import("code")?;
+                let kwargs = PyDict::new(py);
+                kwargs.set_item("banner", "Miden Debugger Python console")?;
+                kwargs.set_item("local", globals)?;
+                code.call_method("interact", (), Some(&kwargs))?;
+                Ok(())
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Import a Python file into this session.
+    ///
+    /// If the module defines `__miden_init_module(debugger, internal_dict)`, the
+    /// initializer is called after the module has been executed.
+    pub fn import_file(&self, path: impl AsRef<Path>) -> Result<(), String> {
+        let path = canonical_python_path(path.as_ref())?;
+        let module_name = module_name_for_path(&path);
+        let module_alias = module_alias_for_path(&path);
+        let path_string = path.to_string_lossy().into_owned();
+
+        Python::attach(|py| {
+            self.with_globals(py, |_| {
+                let importlib_util = py.import("importlib.util")?;
+                let sys = py.import("sys")?;
+                let spec = importlib_util
+                    .call_method1("spec_from_file_location", (&module_name, &path_string))?;
+                if spec.is_none() {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "failed to create import spec for {}",
+                        path.display()
+                    )));
+                }
+
+                let module = importlib_util.call_method1("module_from_spec", (&spec,))?;
+                sys.getattr("modules")?.set_item(&module_name, &module)?;
+                sys.getattr("modules")?.set_item(&module_alias, &module)?;
+                spec.getattr("loader")?.call_method1("exec_module", (&module,))?;
+
+                if let Ok(init) = module.getattr("__miden_init_module") {
+                    let miden_module = py.import("miden_debugger")?;
+                    init.call1((miden_module.getattr("debugger")?, self.internal_dict.bind(py)))?;
+                }
+
+                self.modules.borrow_mut().push(module.cast_into::<PyModule>()?.unbind());
+                Ok(())
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Register a Python-backed custom debugger command.
+    pub fn add_custom_command(&self, name: &str, function_path: &str) -> Result<(), String> {
+        validate_custom_command_name(name)?;
+        Python::attach(|py| {
+            self.with_globals(py, |globals| {
+                let function = resolve_python_callable(py, globals, function_path)?;
+                self.custom_commands.borrow_mut().insert(name.into(), function);
+                Ok(())
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Return registered custom command names.
+    pub fn custom_commands(&self) -> Vec<String> {
+        self.custom_commands.borrow().keys().cloned().collect()
+    }
+
+    /// Delete a registered custom command.
+    pub fn delete_custom_command(&self, name: &str) -> Result<(), String> {
+        if self.custom_commands.borrow_mut().remove(name).is_some() {
+            Ok(())
+        } else {
+            Err(format!("no Python command named `{name}`"))
+        }
+    }
+
+    /// Execute a registered custom command.
+    pub fn execute_custom_command(&self, name: &str, args: &str) -> Result<Option<String>, String> {
+        Python::attach(|py| {
+            self.with_globals(py, |_| {
+                let Some(function) =
+                    self.custom_commands.borrow().get(name).map(|function| function.clone_ref(py))
+                else {
+                    return Ok(None);
+                };
+
+                let result = Py::new(py, PyCommandResult::default())?;
+                function.call1(
+                    py,
+                    (
+                        PyDebugger::new(self.debugger.clone()),
+                        args,
+                        PyExecutionContext::new(self.debugger.clone()),
+                        result.clone_ref(py),
+                        self.internal_dict.bind(py),
+                    ),
+                )?;
+
+                let result = result.borrow(py);
+                if let Some(error) = result.error() {
+                    return Err(PyRuntimeError::new_err(error));
+                }
+                Ok(Some(result.output()))
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Register a Python callback for a breakpoint id.
+    pub fn add_breakpoint_callback(&self, id: u8, function_path: &str) -> Result<(), String> {
+        let exists = self.debugger.borrow().breakpoints().iter().any(|bp| bp.id == id);
+        if !exists {
+            return Err(format!("no breakpoint with id {id}"));
+        }
+
+        Python::attach(|py| {
+            self.with_globals(py, |globals| {
+                let function = resolve_python_callable(py, globals, function_path)?;
+                self.breakpoint_callbacks.borrow_mut().insert(id, function);
+                Ok(())
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+
+    /// Return breakpoint ids with registered Python callbacks.
+    pub fn breakpoint_callbacks(&self) -> Vec<u8> {
+        self.breakpoint_callbacks.borrow().keys().copied().collect()
+    }
+
+    /// Delete one breakpoint callback, or all callbacks when `id` is `None`.
+    pub fn delete_breakpoint_callback(&self, id: Option<u8>) -> Result<(), String> {
+        match id {
+            Some(id) => {
+                if self.breakpoint_callbacks.borrow_mut().remove(&id).is_some() {
+                    Ok(())
+                } else {
+                    Err(format!("no Python callback registered for breakpoint {id}"))
+                }
+            }
+            None => {
+                self.breakpoint_callbacks.borrow_mut().clear();
+                Ok(())
+            }
+        }
+    }
+
+    /// Evaluate callbacks for the current hit breakpoints.
+    pub fn should_continue_after_breakpoint_callbacks(&self) -> Result<bool, String> {
+        let hit_breakpoints = self.debugger.borrow().hit_breakpoints();
+        if hit_breakpoints.is_empty() {
+            return Ok(false);
+        }
+
+        Python::attach(|py| {
+            self.with_globals(py, |_| {
+                for breakpoint in hit_breakpoints {
+                    let Some(callback) = self
+                        .breakpoint_callbacks
+                        .borrow()
+                        .get(&breakpoint.id)
+                        .map(|callback| callback.clone_ref(py))
+                    else {
+                        return Ok(false);
+                    };
+
+                    let result = callback.call1(
+                        py,
+                        (
+                            PyFrame::new(self.debugger.clone()),
+                            PyBreakpoint::new(self.debugger.clone(), breakpoint.id),
+                            self.internal_dict.bind(py),
+                        ),
+                    )?;
+                    if !result.is_none(py) && result.is_truthy(py)? {
+                        return Ok(false);
+                    }
+                }
+
+                Ok(true)
+            })
+        })
+        .map_err(|err| err.to_string())
+    }
+}
+
+impl Drop for PythonScriptSession {
+    fn drop(&mut self) {
+        let _ = Python::try_attach(|py| {
+            if let Ok(sys) = py.import("sys")
+                && let Ok(modules) = sys.getattr("modules")
+            {
+                let _ = modules.del_item("miden_debugger");
+            }
+            self.globals.bind(py).clear();
+            self.internal_dict.bind(py).clear();
+            self.modules.borrow_mut().clear();
+            self.custom_commands.borrow_mut().clear();
+            self.breakpoint_callbacks.borrow_mut().clear();
+        });
+    }
+}
+
+fn canonical_python_path(path: &Path) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|err| format!("failed to resolve Python script {}: {err}", path.display()))
+}
+
+fn module_name_for_path(path: &Path) -> String {
+    let sanitized_stem = module_alias_for_path(path);
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("miden_debugger_user_{}_{}", sanitized_stem, hasher.finish())
+}
+
+fn module_alias_for_path(path: &Path) -> String {
+    let stem = path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("script");
+    let alias = stem
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect::<String>();
+    if alias.is_empty() {
+        "script".into()
+    } else {
+        alias
+    }
+}
+
+fn validate_custom_command_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Python command name must not be empty".into());
+    }
+    if name.chars().any(char::is_whitespace) {
+        return Err(format!("Python command name `{name}` must not contain whitespace"));
+    }
+    Ok(())
+}
+
+fn resolve_python_callable(
+    py: Python<'_>,
+    globals: &Bound<'_, PyDict>,
+    function_path: &str,
+) -> PyResult<Py<PyAny>> {
+    let object = if let Some((module_name, attr_path)) = function_path.split_once('.') {
+        let mut object: Bound<'_, PyAny> = py.import(module_name)?.into_any();
+        for attr in attr_path.split('.') {
+            object = object.getattr(attr)?;
+        }
+        object
+    } else {
+        globals.get_item(function_path)?.ok_or_else(|| {
+            PyKeyError::new_err(format!("no Python object named `{function_path}`"))
+        })?
+    };
+
+    if object.is_callable() {
+        Ok(object.unbind())
+    } else {
+        Err(PyRuntimeError::new_err(format!("`{function_path}` is not callable")))
+    }
+}
+
+fn create_miden_debugger_module(
+    py: Python<'_>,
+    debugger: SharedDebugger,
+) -> PyResult<Bound<'_, PyModule>> {
+    let module = PyModule::new(py, "miden_debugger")?;
+    module.add_class::<PyDebugger>()?;
+    module.add_class::<PyTarget>()?;
+    module.add_class::<PyProcess>()?;
+    module.add_class::<PyThread>()?;
+    module.add_class::<PyFrame>()?;
+    module.add_class::<PyBreakpoint>()?;
+    module.add_class::<PyValue>()?;
+    module.add_class::<PySourceLocation>()?;
+    module.add_class::<PyExecutionContext>()?;
+    module.add_class::<PyCommandResult>()?;
+
+    module.add("debugger", PyDebugger::new(debugger.clone()))?;
+    module.add("target", PyTarget::new(debugger.clone()))?;
+    module.add("process", PyProcess::new(debugger.clone()))?;
+    module.add("thread", PyThread::new(debugger.clone()))?;
+    module.add("frame", PyFrame::new(debugger.clone()))?;
+
+    py.import("sys")?.getattr("modules")?.set_item("miden_debugger", &module)?;
+
+    Ok(module)
+}
+
+fn py_error(error: String) -> PyErr {
+    PyRuntimeError::new_err(error)
+}
+
+fn find_breakpoint(debugger: &SharedDebugger, id: u8) -> PyResult<ScriptBreakpoint> {
+    debugger
+        .borrow()
+        .breakpoints()
+        .into_iter()
+        .find(|bp| bp.id == id)
+        .ok_or_else(|| PyKeyError::new_err(format!("no breakpoint with id {id}")))
+}
+
+#[pyclass(name = "Debugger", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyDebugger {
+    debugger: SharedDebugger,
+}
+
+impl PyDebugger {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyDebugger {
+    fn handle_command(&self, command: &str) -> PyResult<String> {
+        self.debugger.borrow_mut().handle_command(command).map_err(py_error)
+    }
+
+    fn get_selected_target(&self) -> PyTarget {
+        PyTarget::new(self.debugger.clone())
+    }
+
+    fn get_cycle(&self) -> usize {
+        self.debugger.borrow().cycle()
+    }
+
+    fn get_breakpoints(&self) -> Vec<PyBreakpoint> {
+        self.debugger
+            .borrow()
+            .breakpoints()
+            .into_iter()
+            .map(|bp| PyBreakpoint::new(self.debugger.clone(), bp.id))
+            .collect()
+    }
+
+    fn set_breakpoint(&self, spec: &str) -> PyResult<PyBreakpoint> {
+        let bp = self.debugger.borrow_mut().set_breakpoint(spec).map_err(py_error)?;
+        Ok(PyBreakpoint::new(self.debugger.clone(), bp.id))
+    }
+
+    fn delete_breakpoint(&self, id: Option<u8>) -> PyResult<()> {
+        self.debugger.borrow_mut().delete_breakpoint(id).map_err(py_error)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Debugger(cycle={})", self.get_cycle())
+    }
+}
+
+#[pyclass(name = "Target", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyTarget {
+    debugger: SharedDebugger,
+}
+
+impl PyTarget {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyTarget {
+    fn process(&self) -> PyProcess {
+        PyProcess::new(self.debugger.clone())
+    }
+
+    fn source_path_prefixes(&self) -> Vec<String> {
+        self.debugger.borrow().source_path_prefixes()
+    }
+
+    fn __repr__(&self) -> &'static str {
+        "Target()"
+    }
+}
+
+#[pyclass(name = "Process", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyProcess {
+    debugger: SharedDebugger,
+}
+
+impl PyProcess {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyProcess {
+    fn is_stopped(&self) -> bool {
+        self.debugger.borrow().stopped()
+    }
+
+    fn is_terminated(&self) -> bool {
+        self.debugger.borrow().terminated()
+    }
+
+    fn continue_(&self) -> PyResult<String> {
+        self.debugger.borrow_mut().continue_().map_err(py_error)
+    }
+
+    fn step(&self, count: Option<usize>) -> PyResult<String> {
+        self.debugger.borrow_mut().step(count.unwrap_or(1)).map_err(py_error)
+    }
+
+    fn next(&self) -> PyResult<String> {
+        self.debugger.borrow_mut().next().map_err(py_error)
+    }
+
+    fn next_line(&self) -> PyResult<String> {
+        self.debugger.borrow_mut().next_line().map_err(py_error)
+    }
+
+    fn finish(&self) -> PyResult<String> {
+        self.debugger.borrow_mut().finish().map_err(py_error)
+    }
+
+    fn stack(&self) -> Vec<u64> {
+        self.debugger.borrow().stack()
+    }
+
+    fn read_memory(&self, expression: &str) -> PyResult<String> {
+        self.debugger.borrow_mut().read_memory(expression).map_err(py_error)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Process(stopped={}, terminated={})", self.is_stopped(), self.is_terminated())
+    }
+}
+
+#[pyclass(name = "Thread", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyThread {
+    debugger: SharedDebugger,
+}
+
+impl PyThread {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyThread {
+    fn frames(&self) -> Vec<PyFrame> {
+        vec![self.selected_frame()]
+    }
+
+    fn selected_frame(&self) -> PyFrame {
+        PyFrame::new(self.debugger.clone())
+    }
+
+    fn __repr__(&self) -> &'static str {
+        "Thread()"
+    }
+}
+
+#[pyclass(name = "ExecutionContext", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyExecutionContext {
+    debugger: SharedDebugger,
+}
+
+impl PyExecutionContext {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyExecutionContext {
+    fn target(&self) -> PyTarget {
+        PyTarget::new(self.debugger.clone())
+    }
+
+    fn process(&self) -> PyProcess {
+        PyProcess::new(self.debugger.clone())
+    }
+
+    fn thread(&self) -> PyThread {
+        PyThread::new(self.debugger.clone())
+    }
+
+    fn frame(&self) -> PyFrame {
+        PyFrame::new(self.debugger.clone())
+    }
+
+    fn cycle(&self) -> usize {
+        self.debugger.borrow().cycle()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ExecutionContext(cycle={})", self.cycle())
+    }
+}
+
+#[pyclass(name = "CommandResult", unsendable, skip_from_py_object)]
+#[derive(Default)]
+pub struct PyCommandResult {
+    output: RefCell<String>,
+    error: RefCell<Option<String>>,
+}
+
+impl PyCommandResult {
+    fn output(&self) -> String {
+        self.output.borrow().clone()
+    }
+
+    fn error(&self) -> Option<String> {
+        self.error.borrow().clone()
+    }
+}
+
+#[pymethods]
+impl PyCommandResult {
+    fn write(&self, text: &str) {
+        self.output.borrow_mut().push_str(text);
+    }
+
+    fn flush(&self) {}
+
+    fn set_error(&self, message: &str) {
+        *self.error.borrow_mut() = Some(message.into());
+    }
+
+    fn clear(&self) {
+        self.output.borrow_mut().clear();
+        self.error.borrow_mut().take();
+    }
+
+    fn succeeded(&self) -> bool {
+        self.error.borrow().is_none()
+    }
+
+    fn __repr__(&self) -> String {
+        match self.error() {
+            Some(error) => format!("CommandResult(error={error:?})"),
+            None => format!("CommandResult(output={:?})", self.output()),
+        }
+    }
+}
+
+#[pyclass(name = "Frame", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyFrame {
+    debugger: SharedDebugger,
+}
+
+impl PyFrame {
+    fn new(debugger: SharedDebugger) -> Self {
+        Self { debugger }
+    }
+}
+
+#[pymethods]
+impl PyFrame {
+    fn function_name(&self) -> Option<String> {
+        self.debugger.borrow().frame().function_name
+    }
+
+    fn source_location(&self) -> Option<PySourceLocation> {
+        self.debugger.borrow().frame().source_location.map(PySourceLocation::from)
+    }
+
+    fn variables(&self, py: Python<'_>, all: Option<bool>) -> PyResult<Py<PyDict>> {
+        let frame = self.debugger.borrow().frame_with_variables(all.unwrap_or(false));
+        let variables = PyDict::new(py);
+        for value in frame.variables {
+            variables.set_item(value.name.clone(), PyValue::from(value))?;
+        }
+        Ok(variables.unbind())
+    }
+
+    fn __repr__(&self) -> String {
+        match self.function_name() {
+            Some(function) => format!("Frame(function_name={function:?})"),
+            None => "Frame(function_name=None)".into(),
+        }
+    }
+}
+
+#[pyclass(name = "Breakpoint", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyBreakpoint {
+    debugger: SharedDebugger,
+    id: u8,
+}
+
+impl PyBreakpoint {
+    fn new(debugger: SharedDebugger, id: u8) -> Self {
+        Self { debugger, id }
+    }
+
+    fn snapshot(&self) -> PyResult<ScriptBreakpoint> {
+        find_breakpoint(&self.debugger, self.id)
+    }
+}
+
+#[pymethods]
+impl PyBreakpoint {
+    #[getter]
+    fn id(&self) -> u8 {
+        self.id
+    }
+
+    #[getter]
+    fn spec(&self) -> PyResult<String> {
+        Ok(self.snapshot()?.spec)
+    }
+
+    #[getter]
+    fn internal(&self) -> PyResult<bool> {
+        Ok(self.snapshot()?.internal)
+    }
+
+    #[getter]
+    fn one_shot(&self) -> PyResult<bool> {
+        Ok(self.snapshot()?.one_shot)
+    }
+
+    fn delete(&self) -> PyResult<()> {
+        self.debugger.borrow_mut().delete_breakpoint(Some(self.id)).map_err(py_error)
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("Breakpoint(id={}, spec={:?})", self.id, self.spec()?))
+    }
+}
+
+#[pyclass(name = "Value", unsendable, skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyValue {
+    name: String,
+    value: Option<u64>,
+    location: String,
+    source: Option<PySourceLocation>,
+}
+
+impl From<ScriptValue> for PyValue {
+    fn from(value: ScriptValue) -> Self {
+        Self {
+            name: value.name,
+            value: value.value,
+            location: value.location,
+            source: value.source.map(PySourceLocation::from),
+        }
+    }
+}
+
+#[pymethods]
+impl PyValue {
+    #[getter]
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    #[getter]
+    fn value(&self) -> Option<u64> {
+        self.value
+    }
+
+    #[getter]
+    fn location(&self) -> String {
+        self.location.clone()
+    }
+
+    #[getter]
+    fn source(&self) -> Option<PySourceLocation> {
+        self.source.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        match self.value {
+            Some(value) => format!("Value(name={:?}, value={value})", self.name),
+            None => format!("Value(name={:?}, value=None)", self.name),
+        }
+    }
+}
+
+#[pyclass(name = "SourceLocation", unsendable, skip_from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PySourceLocation {
+    path: String,
+    line: u32,
+    column: u32,
+}
+
+impl From<ScriptSourceLocation> for PySourceLocation {
+    fn from(location: ScriptSourceLocation) -> Self {
+        Self {
+            path: location.path,
+            line: location.line,
+            column: location.column,
+        }
+    }
+}
+
+#[pymethods]
+impl PySourceLocation {
+    #[getter]
+    fn path(&self) -> String {
+        self.path.clone()
+    }
+
+    #[getter]
+    fn line(&self) -> u32 {
+        self.line
+    }
+
+    #[getter]
+    fn column(&self) -> u32 {
+        self.column
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SourceLocation(path={:?}, line={}, column={})",
+            self.path, self.line, self.column
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_core::Felt;
+
+    use super::*;
+
+    fn test_debugger() -> ScriptDebugger {
+        ScriptDebugger::from_masm_source(
+            r#"
+begin
+    push.3
+    push.4
+    add
+end
+"#,
+            Vec::<Felt>::new(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn embedded_module_exposes_debugger_globals() {
+        let _guard = python_test_lock();
+        let session = PythonScriptSession::new(test_debugger()).unwrap();
+
+        Python::attach(|py| {
+            let module = py.import("miden_debugger").unwrap();
+            let cycle: usize = module
+                .getattr("debugger")
+                .unwrap()
+                .call_method0("get_cycle")
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(cycle, 0);
+
+            session
+                .with_globals(py, |globals| {
+                    let debugger = globals.get_item("debugger")?.unwrap();
+                    let cycle: usize = debugger.call_method0("get_cycle")?.extract()?;
+                    assert_eq!(cycle, 0);
+                    Ok(())
+                })
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn python_debugger_can_drive_commands() {
+        let _guard = python_test_lock();
+        let session = PythonScriptSession::new(test_debugger()).unwrap();
+
+        Python::attach(|py| {
+            session
+                .with_globals(py, |globals| {
+                    let debugger = globals.get_item("debugger")?.unwrap();
+                    let output: String =
+                        debugger.call_method1("handle_command", ("step",))?.extract()?;
+                    assert!(output.contains("in") || output.is_empty());
+                    let cycle: usize = debugger.call_method0("get_cycle")?.extract()?;
+                    assert_eq!(cycle, 1);
+                    Ok(())
+                })
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn python_snippets_preserve_globals_and_print_expression_values() {
+        let _guard = python_test_lock();
+        let session = PythonScriptSession::new(test_debugger()).unwrap();
+
+        assert_eq!(session.execute_snippet("x = 1").unwrap(), "");
+        assert_eq!(session.execute_snippet("x + 1").unwrap(), "2\n");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,24 +1,38 @@
+#[cfg(feature = "tui")]
 mod action;
+#[cfg(feature = "tui")]
 mod app;
+#[cfg(feature = "tui")]
 mod duration;
+#[cfg(feature = "tui")]
 mod pages;
+#[cfg(feature = "tui")]
 mod panes;
 pub(crate) mod state;
+#[cfg(feature = "tui")]
 mod syntax_highlighting;
+#[cfg(feature = "tui")]
 mod tui;
 
+#[cfg(feature = "tui")]
 use log::LevelFilter;
+#[cfg(feature = "tui")]
 use miden_assembly_syntax::diagnostics::{IntoDiagnostic, Report};
 
+#[cfg(feature = "tui")]
 pub use self::state::{DebugMode, State};
+#[cfg(feature = "tui")]
 use self::{action::Action, app::App};
+#[cfg(feature = "tui")]
 use crate::config::DebuggerConfig;
 
+#[cfg(feature = "tui")]
 #[allow(dead_code)]
 pub fn run(config: Box<DebuggerConfig>, logger: Box<dyn log::Log>) -> Result<(), Report> {
     run_with_log_level(config, logger, LevelFilter::Trace)
 }
 
+#[cfg(feature = "tui")]
 pub fn run_with_log_level(
     config: Box<DebuggerConfig>,
     logger: Box<dyn log::Log>,
@@ -33,11 +47,13 @@ pub fn run_with_log_level(
 ///
 /// This is the programmatic entry point used by transaction debugging, where
 /// the caller constructs a [State] with pre-recorded event replay data.
+#[cfg(feature = "tui")]
 pub fn run_with_state(state: State, logger: Box<dyn log::Log>) -> Result<(), Report> {
     run_with_state_and_log_level(state, logger, LevelFilter::Trace)
 }
 
 /// Launch the TUI debugger with a pre-built [State] and log level filter.
+#[cfg(feature = "tui")]
 pub fn run_with_state_and_log_level(
     state: State,
     logger: Box<dyn log::Log>,
@@ -48,6 +64,7 @@ pub fn run_with_state_and_log_level(
     rt.block_on(async move { start_ui_with_state(state, logger, max_level).await })
 }
 
+#[cfg(feature = "tui")]
 #[allow(dead_code)]
 pub async fn start_ui(
     config: Box<DebuggerConfig>,
@@ -71,6 +88,7 @@ pub async fn start_ui(
     Ok(())
 }
 
+#[cfg(feature = "tui")]
 async fn start_ui_with_state(
     state: State,
     logger: Box<dyn log::Log>,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -81,6 +81,23 @@ pub enum InputMode {
     Command,
 }
 
+/// Source location attached to a source-level debug variable declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugVariableSource {
+    pub path: String,
+    pub line: u32,
+    pub column: u32,
+}
+
+/// Structured view of a variable visible to debugger frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugVariableValue {
+    pub name: String,
+    pub value: Option<Felt>,
+    pub location: String,
+    pub source: Option<DebugVariableSource>,
+}
+
 struct LocalState {
     executor: DebugExecutor,
     execution_failed: Option<miden_processor::ExecutionError>,
@@ -277,6 +294,30 @@ impl State {
         let local = create_local_state(&config, source_manager.clone())?;
 
         Ok(Self::new_local(source_manager, config, DebugMode::Program, local))
+    }
+
+    /// Create a debugger state directly from inline Miden Assembly source.
+    ///
+    /// This is used by the scripting API for tests and small programmatic
+    /// debugging harnesses, where there is no compiled package to load.
+    pub fn from_masm_source(source: &str, args: Vec<Felt>) -> Result<Self, Report> {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let program =
+            miden_assembly::Assembler::new(source_manager.clone()).assemble_program(source)?;
+        // CLI/test args model sequential pushes, but the executor expects the
+        // top-of-stack element first.
+        let args = args.into_iter().rev().collect::<Vec<_>>();
+        let executor = Executor::new(args).into_debug(&program, source_manager.clone());
+
+        Ok(Self::new_local(
+            source_manager,
+            Box::<DebuggerConfig>::default(),
+            DebugMode::Program,
+            LocalState {
+                executor,
+                execution_failed: None,
+            },
+        ))
     }
 
     /// Create a new debugger state for transaction debugging.
@@ -935,17 +976,14 @@ impl State {
         Ok(output)
     }
 
-    /// Format the current debug variables as a string for display.
+    /// Collect the current debug variables as structured records.
     ///
     /// When `show_all` is false, compiler-generated locals (named `local0`, `local1`, etc.)
     /// are hidden. Use `show_all` = true (`:vars all`) to include them.
-    pub fn format_variables(&self, show_all: bool) -> String {
-        use core::fmt::Write;
-
+    pub fn current_variables(&self, show_all: bool) -> Vec<DebugVariableValue> {
         let executor = self.executor();
         let debug_vars = &executor.debug_vars;
 
-        let mut output = String::new();
         let stack = executor.current_stack.clone();
         let context = executor.current_context;
 
@@ -965,9 +1003,7 @@ impl State {
         };
         let source_path_prefixes = self.source_path_prefixes();
 
-        if !debug_vars.has_variables() {
-            return "No debug variables tracked".to_string();
-        }
+        let mut variables = Vec::new();
 
         for var_snapshot in debug_vars.current_variables() {
             let name = var_snapshot.info.name();
@@ -989,10 +1025,6 @@ impl State {
                 continue;
             }
 
-            if !output.is_empty() {
-                output.push_str(", ");
-            }
-
             let location = var_snapshot.info.value_location();
 
             let value = resolve_variable_value(location, &stack, read_mem, |offset| {
@@ -1003,19 +1035,54 @@ impl State {
                 read_mem(addr)
             });
 
-            match value {
-                Some(felt) => {
-                    write!(&mut output, "{name}={}", felt.as_canonical_u64()).unwrap();
-                }
-                None => {
-                    write!(&mut output, "{name}={location}").unwrap();
-                }
-            }
+            let source = var_snapshot.info.location().map(|loc| DebugVariableSource {
+                path: loc.uri.as_str().to_string(),
+                line: loc.line.to_u32(),
+                column: loc.column.to_u32(),
+            });
+
+            variables.push(DebugVariableValue {
+                name: name.to_string(),
+                value,
+                location: location.to_string(),
+                source,
+            });
         }
 
-        if output.is_empty() {
+        variables
+    }
+
+    /// Format the current debug variables as a string for display.
+    ///
+    /// When `show_all` is false, compiler-generated locals (named `local0`, `local1`, etc.)
+    /// are hidden. Use `show_all` = true (`:vars all`) to include them.
+    pub fn format_variables(&self, show_all: bool) -> String {
+        use core::fmt::Write;
+
+        if !self.executor().debug_vars.has_variables() {
+            return "No debug variables tracked".to_string();
+        }
+
+        let variables = self.current_variables(show_all);
+        if variables.is_empty() {
             "No source-level variables (use ':vars all' to show compiler locals)".to_string()
         } else {
+            let mut output = String::new();
+            for variable in variables {
+                if !output.is_empty() {
+                    output.push_str(", ");
+                }
+
+                match variable.value {
+                    Some(felt) => {
+                        write!(&mut output, "{}={}", variable.name, felt.as_canonical_u64())
+                            .unwrap();
+                    }
+                    None => {
+                        write!(&mut output, "{}={}", variable.name, variable.location).unwrap();
+                    }
+                }
+            }
             output
         }
     }


### PR DESCRIPTION
An example of using it:

```bash
[cycle 0 STOP] > command script import ../miden-debug/examples/python/dump_stack.py
Imported Python script: ../miden-debug/examples/python/dump_stack.py
[cycle 0 STOP] > command script add py-stack -f dump_stack.dump_stack
Added Python command: py-stack
[cycle 0 STOP] > s 2
at ::$exec:2:5 in ::$exec::$main
[cycle 2 STOP] > py-stack
00: 2147483648
01: 0
02: 0
03: 0
04: 0
05: 0
06: 0
07: 0
08: 0
09: 0
10: 0
11: 0
12: 0
13: 0
14: 0
15: 0
16: 0
```

An the script is:

```bash
cat ../miden-debug/examples/python/dump_stack.py
def dump_stack(debugger, command, exe_ctx, result, internal_dict):
    stack = exe_ctx.process().stack()
    for index, value in enumerate(stack):
        print(f"{index:02}: {value}", file=result)
```

This is very useful for testing of debugger itself as well.