### PR TITLE
build: run `format-rust` on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           # But do not save this cache, just use it
           save-if: false
       - *install-cargo-make
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal --component rustfmt
       - name: Check Formatting
         run: |
           cargo make check-format

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -152,6 +152,7 @@ dependencies = ["format-rust"]
 description = "Runs cargo fmt to check appropriate code format."
 category = "Test"
 command = "cargo"
+toolchain = "nightly"
 args = ["fmt", "--", "--check"]
 dependencies = ["install-rustfmt"]
 


### PR DESCRIPTION
`rust-toolchain.toml` sets `channel = "1.94"` and `rustfmt.toml` contains options that are available only on `nightly`. Therefore `cargo make check-format` produces warnings that make CI fail:

```sh
❯ cargo fmt
Warning: can't set `wrap_comments = false`, unstable features are only available in nightly channel.
Warning: can't set `comment_width = 100`, unstable features are only available in nightly channel.
Warning: can't set `format_strings = true`, unstable features are only available in nightly channel.
[...clipped]
```

Proposed fix: run task `check-format` on `nightly`, aligning it with `format-rust`.

### Why the second commit

After the first commit the `check_format` workflow failed with `Missing toolchain nightly! Please install it using rustup.` [ref](https://github.com/0xMiden/miden-debug/actions/runs/27938618250/job/82666841287#step:6:61)