### PR TITLE
feat(engine): record advice mutations from event handlers for replay

### DIFF
--- a/crates/engine/src/exec/advice.rs
+++ b/crates/engine/src/exec/advice.rs
@@ -48,6 +48,12 @@ pub struct EventMutationRecorder {
     log: Arc<Mutex<Vec<Vec<AdviceMutation>>>>,
 }
 
+impl core::fmt::Debug for EventMutationRecorder {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EventMutationRecorder").field("events", &self.len()).finish()
+    }
+}
+
 impl EventMutationRecorder {
     /// Create a new, empty recorder.
     pub fn new() -> Self {

--- a/crates/engine/src/exec/advice.rs
+++ b/crates/engine/src/exec/advice.rs
@@ -1,0 +1,89 @@
+//! Support utilities for working with [AdviceMutation]s, in particular cloning and recording
+//! the mutations produced by event handlers so they can be replayed later.
+
+use std::sync::{Arc, Mutex};
+
+use miden_processor::advice::AdviceMutation;
+
+/// Clone a single [AdviceMutation].
+///
+/// [AdviceMutation] does not implement [Clone] upstream, so recording and replaying event
+/// mutations requires reconstructing each variant by hand.
+pub fn clone_advice_mutation(mutation: &AdviceMutation) -> AdviceMutation {
+    match mutation {
+        AdviceMutation::ExtendStack { values } => AdviceMutation::ExtendStack {
+            values: values.clone(),
+        },
+        AdviceMutation::ExtendMap { other } => AdviceMutation::ExtendMap {
+            other: other.clone(),
+        },
+        AdviceMutation::ExtendMerkleStore { infos } => AdviceMutation::ExtendMerkleStore {
+            infos: infos.clone(),
+        },
+        AdviceMutation::ExtendPrecompileRequests { data } => {
+            AdviceMutation::ExtendPrecompileRequests { data: data.clone() }
+        }
+    }
+}
+
+/// Clone a batch of [AdviceMutation]s. See [clone_advice_mutation].
+pub fn clone_advice_mutations(mutations: &[AdviceMutation]) -> Vec<AdviceMutation> {
+    mutations.iter().map(clone_advice_mutation).collect()
+}
+
+/// A shared, cloneable log of the advice mutations produced by event handlers.
+///
+/// One entry is recorded per `on_event` invocation, in execution order, **including empty
+/// mutation sets**: event replay pops exactly one entry per event, so the log must stay aligned
+/// with the event stream of the recorded execution.
+///
+/// Attach a recorder to a live execution (see `DebuggerHost::set_event_recorder` or
+/// `DapExecutor::record_event_mutations`), run the program to completion, and feed the recorded
+/// log into `DebuggerHost::set_event_replay` (or `Executor::into_debug_with_replay`) to debug
+/// the same execution later without access to the original host's event handlers.
+#[derive(Clone, Default)]
+pub struct EventMutationRecorder {
+    log: Arc<Mutex<Vec<Vec<AdviceMutation>>>>,
+}
+
+impl EventMutationRecorder {
+    /// Create a new, empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the recorded mutation batches, leaving the recorder empty.
+    pub fn take(&self) -> Vec<Vec<AdviceMutation>> {
+        core::mem::take(&mut *self.log.lock().expect("event mutation log poisoned"))
+    }
+
+    /// Returns a copy of the recorded mutation batches, leaving the recorder intact.
+    pub fn snapshot(&self) -> Vec<Vec<AdviceMutation>> {
+        self.log
+            .lock()
+            .expect("event mutation log poisoned")
+            .iter()
+            .map(|batch| clone_advice_mutations(batch))
+            .collect()
+    }
+
+    /// The number of `on_event` invocations recorded so far.
+    pub fn len(&self) -> usize {
+        self.log.lock().expect("event mutation log poisoned").len()
+    }
+
+    /// Returns true if no `on_event` invocations have been recorded.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Record the mutations produced by one `on_event` invocation.
+    pub(crate) fn record(&self, mutations: Vec<AdviceMutation>) {
+        self.log.lock().expect("event mutation log poisoned").push(mutations);
+    }
+
+    /// Discard everything recorded so far, e.g. when execution restarts from the beginning.
+    pub(crate) fn clear(&self) {
+        self.log.lock().expect("event mutation log poisoned").clear();
+    }
+}

--- a/crates/engine/src/exec/advice.rs
+++ b/crates/engine/src/exec/advice.rs
@@ -37,10 +37,12 @@ pub fn clone_advice_mutations(mutations: &[AdviceMutation]) -> Vec<AdviceMutatio
 /// mutation sets**: event replay pops exactly one entry per event, so the log must stay aligned
 /// with the event stream of the recorded execution.
 ///
-/// Attach a recorder to a live execution (see `DebuggerHost::set_event_recorder` or
-/// `DapExecutor::record_event_mutations`), run the program to completion, and feed the recorded
-/// log into `DebuggerHost::set_event_replay` (or `Executor::into_debug_with_replay`) to debug
-/// the same execution later without access to the original host's event handlers.
+/// This handle exists for executors that are consumed by execution and whose return type cannot
+/// carry the log (see `DapExecutor::record_event_mutations`): obtain it before running, read it
+/// once execution completes, and feed the recorded log into `DebuggerHost::set_event_replay`
+/// (or `Executor::into_debug_with_replay`) to debug the same execution later without access to
+/// the original host's event handlers. Hosts owned by the caller record internally instead; see
+/// `DebuggerHost::with_event_advice_mutations_recording`.
 #[derive(Clone, Default)]
 pub struct EventMutationRecorder {
     log: Arc<Mutex<Vec<Vec<AdviceMutation>>>>,

--- a/crates/engine/src/exec/advice.rs
+++ b/crates/engine/src/exec/advice.rs
@@ -1,9 +1,15 @@
-//! Support utilities for working with [AdviceMutation]s, in particular cloning and recording
-//! the mutations produced by event handlers so they can be replayed later.
+//! Support utilities for working with [AdviceMutation]s, in particular cloning, recording, and
+//! (de)serializing the mutations produced by event handlers so they can be replayed later.
 
 use std::sync::{Arc, Mutex};
 
-use miden_processor::advice::AdviceMutation;
+use miden_core::{
+    Felt, Word,
+    crypto::merkle::InnerNodeInfo,
+    precompile::PrecompileRequest,
+    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
+use miden_processor::advice::{AdviceMap, AdviceMutation};
 
 /// Clone a single [AdviceMutation].
 ///
@@ -29,6 +35,102 @@ pub fn clone_advice_mutation(mutation: &AdviceMutation) -> AdviceMutation {
 /// Clone a batch of [AdviceMutation]s. See [clone_advice_mutation].
 pub fn clone_advice_mutations(mutations: &[AdviceMutation]) -> Vec<AdviceMutation> {
     mutations.iter().map(clone_advice_mutation).collect()
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+// Variant tags for the manual [AdviceMutation] encoding. [AdviceMutation] does not implement the
+// serialization traits upstream, so — as with cloning — each variant is (de)serialized by hand.
+const TAG_EXTEND_STACK: u8 = 0;
+const TAG_EXTEND_MAP: u8 = 1;
+const TAG_EXTEND_MERKLE_STORE: u8 = 2;
+const TAG_EXTEND_PRECOMPILE_REQUESTS: u8 = 3;
+
+/// Serialize a single [AdviceMutation] into `target`.
+pub fn write_advice_mutation<W: ByteWriter>(mutation: &AdviceMutation, target: &mut W) {
+    match mutation {
+        AdviceMutation::ExtendStack { values } => {
+            target.write_u8(TAG_EXTEND_STACK);
+            values.write_into(target);
+        }
+        AdviceMutation::ExtendMap { other } => {
+            target.write_u8(TAG_EXTEND_MAP);
+            other.write_into(target);
+        }
+        AdviceMutation::ExtendMerkleStore { infos } => {
+            target.write_u8(TAG_EXTEND_MERKLE_STORE);
+            target.write_usize(infos.len());
+            for info in infos {
+                info.value.write_into(target);
+                info.left.write_into(target);
+                info.right.write_into(target);
+            }
+        }
+        AdviceMutation::ExtendPrecompileRequests { data } => {
+            target.write_u8(TAG_EXTEND_PRECOMPILE_REQUESTS);
+            data.write_into(target);
+        }
+    }
+}
+
+/// Deserialize a single [AdviceMutation] from `source`.
+pub fn read_advice_mutation<R: ByteReader>(
+    source: &mut R,
+) -> Result<AdviceMutation, DeserializationError> {
+    match source.read_u8()? {
+        TAG_EXTEND_STACK => Ok(AdviceMutation::ExtendStack {
+            values: Vec::<Felt>::read_from(source)?,
+        }),
+        TAG_EXTEND_MAP => Ok(AdviceMutation::ExtendMap {
+            other: AdviceMap::read_from(source)?,
+        }),
+        TAG_EXTEND_MERKLE_STORE => {
+            let len = source.read_usize()?;
+            let mut infos = Vec::with_capacity(len);
+            for _ in 0..len {
+                let value = Word::read_from(source)?;
+                let left = Word::read_from(source)?;
+                let right = Word::read_from(source)?;
+                infos.push(InnerNodeInfo { value, left, right });
+            }
+            Ok(AdviceMutation::ExtendMerkleStore { infos })
+        }
+        TAG_EXTEND_PRECOMPILE_REQUESTS => Ok(AdviceMutation::ExtendPrecompileRequests {
+            data: Vec::<PrecompileRequest>::read_from(source)?,
+        }),
+        other => Err(DeserializationError::InvalidValue(format!(
+            "unknown AdviceMutation variant tag: {other}"
+        ))),
+    }
+}
+
+/// Serialize a recorded event log (one entry per `on_event` invocation) into `target`.
+pub fn write_event_log<W: ByteWriter>(log: &[Vec<AdviceMutation>], target: &mut W) {
+    target.write_usize(log.len());
+    for batch in log {
+        target.write_usize(batch.len());
+        for mutation in batch {
+            write_advice_mutation(mutation, target);
+        }
+    }
+}
+
+/// Deserialize a recorded event log from `source`.
+pub fn read_event_log<R: ByteReader>(
+    source: &mut R,
+) -> Result<Vec<Vec<AdviceMutation>>, DeserializationError> {
+    let batches = source.read_usize()?;
+    let mut log = Vec::with_capacity(batches);
+    for _ in 0..batches {
+        let len = source.read_usize()?;
+        let mut batch = Vec::with_capacity(len);
+        for _ in 0..len {
+            batch.push(read_advice_mutation(source)?);
+        }
+        log.push(batch);
+    }
+    Ok(log)
 }
 
 /// A shared, cloneable log of the advice mutations produced by event handlers.

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -1814,34 +1814,14 @@ impl DapExecutor {
             // If a snapshot path is configured, persist a self-contained replay snapshot of this
             // (final) run: program, inputs, resolved forests, and the recorded event log.
             if let Some(path) = self.config.snapshot_path.as_ref() {
-                let event_log = self
-                    .event_recorder
-                    .as_ref()
-                    .map(EventMutationRecorder::take)
-                    .unwrap_or_default();
-                let mast_forests = self
-                    .forest_recorder
-                    .as_ref()
-                    .map(MastForestRecorder::snapshot)
-                    .unwrap_or_default();
-                let snapshot = ReplaySnapshot {
-                    program: program.clone(),
+                write_replay_snapshot(
+                    path,
+                    self.event_recorder.as_ref(),
+                    self.forest_recorder.as_ref(),
+                    program,
                     stack_inputs,
-                    advice_inputs: advice_inputs.clone(),
-                    mast_forests,
-                    event_log,
-                };
-                match snapshot.write_to_file(path) {
-                    Ok(()) => eprintln!(
-                        "Wrote replay snapshot ({} event(s), {} forest(s)) to {}",
-                        snapshot.event_log.len(),
-                        snapshot.mast_forests.len(),
-                        path.display()
-                    ),
-                    Err(err) => {
-                        eprintln!("Failed to write replay snapshot to {}: {err}", path.display())
-                    }
-                }
+                    &advice_inputs,
+                );
             }
 
             // Build ExecutionOutput from the processor's final state.
@@ -1857,6 +1837,40 @@ impl DapExecutor {
                 final_precompile_transcript,
             });
         } // end outer restart loop
+    }
+}
+
+/// Build and write a [ReplaySnapshot] of the current run to `path`.
+///
+/// Reads the recorders without draining them (via their `snapshot()`), so a caller that also
+/// reads the shared event recorder afterwards — e.g. an embedder reporting how many mutation sets
+/// were recorded — still sees the full log. Called on every terminal outcome, clean exit or a
+/// failed step, so a failing transaction is captured and replayable too.
+fn write_replay_snapshot(
+    path: &std::path::Path,
+    event_recorder: Option<&EventMutationRecorder>,
+    forest_recorder: Option<&MastForestRecorder>,
+    program: &Program,
+    stack_inputs: StackInputs,
+    advice_inputs: &AdviceInputs,
+) {
+    let event_log = event_recorder.map(EventMutationRecorder::snapshot).unwrap_or_default();
+    let mast_forests = forest_recorder.map(MastForestRecorder::snapshot).unwrap_or_default();
+    let snapshot = ReplaySnapshot {
+        program: program.clone(),
+        stack_inputs,
+        advice_inputs: advice_inputs.clone(),
+        mast_forests,
+        event_log,
+    };
+    match snapshot.write_to_file(path) {
+        Ok(()) => eprintln!(
+            "Wrote replay snapshot ({} event(s), {} forest(s)) to {}",
+            snapshot.event_log.len(),
+            snapshot.mast_forests.len(),
+            path.display()
+        ),
+        Err(err) => eprintln!("Failed to write replay snapshot to {}: {err}", path.display()),
     }
 }
 

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -1259,6 +1259,17 @@ impl DapExecutor {
                             }
                             StepResult::Error(e) => {
                                 server.send_event(Event::Terminated(None)).ok();
+                                // Capture the failed run so it can still be replayed offline.
+                                if let Some(path) = self.config.snapshot_path.as_ref() {
+                                    write_replay_snapshot(
+                                        path,
+                                        self.event_recorder.as_ref(),
+                                        self.forest_recorder.as_ref(),
+                                        program,
+                                        stack_inputs,
+                                        &advice_inputs,
+                                    );
+                                }
                                 return Err(e);
                             }
                         }
@@ -1313,6 +1324,17 @@ impl DapExecutor {
                             }
                             StepResult::Error(e) => {
                                 server.send_event(Event::Terminated(None)).ok();
+                                // Capture the failed run so it can still be replayed offline.
+                                if let Some(path) = self.config.snapshot_path.as_ref() {
+                                    write_replay_snapshot(
+                                        path,
+                                        self.event_recorder.as_ref(),
+                                        self.forest_recorder.as_ref(),
+                                        program,
+                                        stack_inputs,
+                                        &advice_inputs,
+                                    );
+                                }
                                 return Err(e);
                             }
                         }
@@ -1349,6 +1371,17 @@ impl DapExecutor {
                             }
                             StepResult::Error(e) => {
                                 server.send_event(Event::Terminated(None)).ok();
+                                // Capture the failed run so it can still be replayed offline.
+                                if let Some(path) = self.config.snapshot_path.as_ref() {
+                                    write_replay_snapshot(
+                                        path,
+                                        self.event_recorder.as_ref(),
+                                        self.forest_recorder.as_ref(),
+                                        program,
+                                        stack_inputs,
+                                        &advice_inputs,
+                                    );
+                                }
                                 return Err(e);
                             }
                         }
@@ -1385,6 +1418,17 @@ impl DapExecutor {
                             }
                             StepResult::Error(e) => {
                                 server.send_event(Event::Terminated(None)).ok();
+                                // Capture the failed run so it can still be replayed offline.
+                                if let Some(path) = self.config.snapshot_path.as_ref() {
+                                    write_replay_snapshot(
+                                        path,
+                                        self.event_recorder.as_ref(),
+                                        self.forest_recorder.as_ref(),
+                                        program,
+                                        stack_inputs,
+                                        &advice_inputs,
+                                    );
+                                }
                                 return Err(e);
                             }
                         }
@@ -1806,7 +1850,20 @@ impl DapExecutor {
                             ctx = Some(new_ctx);
                         }
                         Ok(None) => break,
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            // Capture the run up to the failure so it can still be replayed.
+                            if let Some(path) = self.config.snapshot_path.as_ref() {
+                                write_replay_snapshot(
+                                    path,
+                                    self.event_recorder.as_ref(),
+                                    self.forest_recorder.as_ref(),
+                                    program,
+                                    stack_inputs,
+                                    &advice_inputs,
+                                );
+                            }
+                            return Err(e);
+                        }
                     }
                 }
             }

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -28,7 +28,10 @@ use miden_processor::{
     trace::RowIndex,
 };
 
-use super::{EventMutationRecorder, TraceEvent, state::extract_current_op};
+use super::{
+    EventMutationRecorder, MastForestRecorder, ReplaySnapshot, TraceEvent,
+    state::extract_current_op,
+};
 use crate::debug::{
     DebugVarSnapshot, DebugVarTracker, FormatType, ReadMemoryExpr, resolve_variable_value,
     snapshot_transient_debug_values,
@@ -54,6 +57,9 @@ pub struct DapConfig {
     /// When set, the advice mutations produced by the host's event handlers are recorded into
     /// this shared log during the session. See [DapConfig::record_event_mutations].
     event_recorder: Option<EventMutationRecorder>,
+    /// When set, a [ReplaySnapshot] of the session is written to this path once execution
+    /// completes. See [DapConfig::record_snapshot].
+    snapshot_path: Option<PathBuf>,
 }
 
 impl DapConfig {
@@ -63,6 +69,7 @@ impl DapConfig {
             source_path_prefixes: Vec::new(),
             restart_requested: Arc::new(AtomicBool::new(false)),
             event_recorder: None,
+            snapshot_path: None,
         }
     }
 
@@ -90,6 +97,17 @@ impl DapConfig {
     /// host's event handlers.
     pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
         self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
+    }
+
+    /// Write a [ReplaySnapshot] of the session to `path` once execution completes.
+    ///
+    /// The snapshot captures the program, its stack and advice inputs, the MAST forests the host
+    /// resolved, and the recorded event log — everything an event-replay debugging session needs
+    /// to re-execute the same program later without the original host (e.g.
+    /// `miden-debug --replay <path>`). It always describes the final run, since the recorded state
+    /// is reset whenever the session restarts execution from the beginning.
+    pub fn record_snapshot(&mut self, path: impl Into<PathBuf>) {
+        self.snapshot_path = Some(path.into());
     }
 
     /// Returns `true` if the server has signalled a Phase 2 restart.
@@ -138,15 +156,23 @@ struct DapHostWrapper<'a, H: Host> {
     /// are recorded here, in execution order, so they can be replayed later (e.g. transaction
     /// debugging with event replay).
     event_recorder: Option<EventMutationRecorder>,
+    /// When set, the MAST forests the inner host resolves are recorded here, so a replay session
+    /// can load the same code for `call`/`dyncall` targets.
+    forest_recorder: Option<MastForestRecorder>,
 }
 
 impl<'a, H: Host> DapHostWrapper<'a, H> {
-    fn new(inner: &'a mut H, event_recorder: Option<EventMutationRecorder>) -> Self {
+    fn new(
+        inner: &'a mut H,
+        event_recorder: Option<EventMutationRecorder>,
+        forest_recorder: Option<MastForestRecorder>,
+    ) -> Self {
         Self {
             inner,
             call_depth: 0,
             frames: Vec::new(),
             event_recorder,
+            forest_recorder,
         }
     }
 }
@@ -198,7 +224,17 @@ impl<H: Host> BaseHost for DapHostWrapper<'_, H> {
 
 impl<H: Host> Host for DapHostWrapper<'_, H> {
     fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        self.inner.get_mast_forest(node_digest)
+        // Record every forest the inner host resolves, so a replay session can load the same
+        // code for `call`/`dyncall` targets. The recorder deduplicates.
+        let forest_recorder = self.forest_recorder.clone();
+        let fut = self.inner.get_mast_forest(node_digest);
+        async move {
+            let forest = fut.await;
+            if let (Some(recorder), Some(forest)) = (&forest_recorder, &forest) {
+                recorder.record(forest.clone());
+            }
+            forest
+        }
     }
 
     fn on_event(
@@ -857,6 +893,7 @@ pub struct DapExecutor {
     options: ExecutionOptions,
     config: DapConfig,
     event_recorder: Option<EventMutationRecorder>,
+    forest_recorder: Option<MastForestRecorder>,
 }
 
 /// Variables reference IDs for scopes.
@@ -883,13 +920,24 @@ impl DapExecutor {
         options: ExecutionOptions,
     ) -> Self {
         let config = DAP_CONFIG.get().cloned().unwrap_or_default();
-        let event_recorder = config.event_recorder.clone();
+        // Writing a snapshot requires both the event log and the resolved forests. Ensure an
+        // event recorder exists (reusing the config's shared one if present) and turn on forest
+        // recording whenever a snapshot path is configured.
+        let (event_recorder, forest_recorder) = if config.snapshot_path.is_some() {
+            (
+                Some(config.event_recorder.clone().unwrap_or_default()),
+                Some(MastForestRecorder::new()),
+            )
+        } else {
+            (config.event_recorder.clone(), None)
+        };
         DapExecutor {
             stack_inputs,
             advice_inputs,
             options,
             config,
             event_recorder,
+            forest_recorder,
         }
     }
 
@@ -1002,12 +1050,19 @@ impl DapExecutor {
                     .expect("advice inputs should fit advice map limits");
 
             let resume_ctx = processor.get_initial_resume_context(program)?;
-            // Each pass through this loop starts execution from the beginning, so any
-            // mutations recorded by a previous (restarted) run no longer apply.
+            // Each pass through this loop starts execution from the beginning, so any mutations
+            // or forests recorded by a previous (restarted) run no longer apply.
             if let Some(recorder) = self.event_recorder.as_ref() {
                 recorder.clear();
             }
-            let mut wrapper = DapHostWrapper::new(host, self.event_recorder.clone());
+            if let Some(recorder) = self.forest_recorder.as_ref() {
+                recorder.clear();
+            }
+            let mut wrapper = DapHostWrapper::new(
+                host,
+                self.event_recorder.clone(),
+                self.forest_recorder.clone(),
+            );
 
             let mut resume_ctx = Some(resume_ctx);
             let mut cycle: usize = 0;
@@ -1756,6 +1811,39 @@ impl DapExecutor {
                 }
             }
 
+            // If a snapshot path is configured, persist a self-contained replay snapshot of this
+            // (final) run: program, inputs, resolved forests, and the recorded event log.
+            if let Some(path) = self.config.snapshot_path.as_ref() {
+                let event_log = self
+                    .event_recorder
+                    .as_ref()
+                    .map(EventMutationRecorder::take)
+                    .unwrap_or_default();
+                let mast_forests = self
+                    .forest_recorder
+                    .as_ref()
+                    .map(MastForestRecorder::snapshot)
+                    .unwrap_or_default();
+                let snapshot = ReplaySnapshot {
+                    program: program.clone(),
+                    stack_inputs,
+                    advice_inputs: advice_inputs.clone(),
+                    mast_forests,
+                    event_log,
+                };
+                match snapshot.write_to_file(path) {
+                    Ok(()) => eprintln!(
+                        "Wrote replay snapshot ({} event(s), {} forest(s)) to {}",
+                        snapshot.event_log.len(),
+                        snapshot.mast_forests.len(),
+                        path.display()
+                    ),
+                    Err(err) => {
+                        eprintln!("Failed to write replay snapshot to {}: {err}", path.display())
+                    }
+                }
+            }
+
             // Build ExecutionOutput from the processor's final state.
             let stack_top: Vec<_> = processor.stack_top().iter().rev().copied().collect();
             let stack = StackOutputs::new(&stack_top)
@@ -2201,7 +2289,7 @@ mod tests {
         .expect("failed to register event handler");
 
         let recorder = EventMutationRecorder::new();
-        let mut wrapper = DapHostWrapper::new(&mut host, Some(recorder.clone()));
+        let mut wrapper = DapHostWrapper::new(&mut host, Some(recorder.clone()), None);
 
         let mut processor = FastProcessor::new_with_options(
             StackInputs::new(&[]).unwrap(),

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -28,7 +28,7 @@ use miden_processor::{
     trace::RowIndex,
 };
 
-use super::{TraceEvent, state::extract_current_op};
+use super::{EventMutationRecorder, TraceEvent, state::extract_current_op};
 use crate::debug::{
     DebugVarSnapshot, DebugVarTracker, FormatType, ReadMemoryExpr, resolve_variable_value,
     snapshot_transient_debug_values,
@@ -113,14 +113,19 @@ struct DapHostWrapper<'a, H: Host> {
     inner: &'a mut H,
     call_depth: usize,
     frames: Vec<DapCallFrame>,
+    /// When set, the advice mutations produced by each `on_event` invocation of the inner host
+    /// are recorded here, in execution order, so they can be replayed later (e.g. transaction
+    /// debugging with event replay).
+    event_recorder: Option<EventMutationRecorder>,
 }
 
 impl<'a, H: Host> DapHostWrapper<'a, H> {
-    fn new(inner: &'a mut H) -> Self {
+    fn new(inner: &'a mut H, event_recorder: Option<EventMutationRecorder>) -> Self {
         Self {
             inner,
             call_depth: 0,
             frames: Vec::new(),
+            event_recorder,
         }
     }
 }
@@ -179,7 +184,17 @@ impl<H: Host> Host for DapHostWrapper<'_, H> {
         &mut self,
         process: &ProcessorState<'_>,
     ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        self.inner.on_event(process)
+        // Every invocation is recorded, including empty mutation sets: event replay pops one
+        // entry per event, so the log must stay aligned with the event stream.
+        let recorder = self.event_recorder.clone();
+        let fut = self.inner.on_event(process);
+        async move {
+            let result = fut.await;
+            if let (Some(recorder), Ok(mutations)) = (&recorder, &result) {
+                recorder.record(crate::exec::clone_advice_mutations(mutations));
+            }
+            result
+        }
     }
 }
 
@@ -820,6 +835,7 @@ pub struct DapExecutor {
     advice_inputs: AdviceInputs,
     options: ExecutionOptions,
     config: DapConfig,
+    event_recorder: Option<EventMutationRecorder>,
 }
 
 /// Variables reference IDs for scopes.
@@ -851,7 +867,22 @@ impl DapExecutor {
             advice_inputs,
             options,
             config,
+            event_recorder: None,
         }
+    }
+
+    /// Record the advice mutations produced by each event handler invocation of the wrapped
+    /// host during execution.
+    ///
+    /// Returns a handle to the shared log. One entry is recorded per `on_event` invocation, in
+    /// execution order, including empty mutation sets, so the log can be fed directly into an
+    /// event replay queue (e.g. `Executor::into_debug_with_replay` or
+    /// `State::new_for_transaction`) to debug the same execution later without access to the
+    /// original host. The log is cleared automatically whenever the DAP session restarts
+    /// execution from the beginning, so after execution completes it always describes the final
+    /// run.
+    pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
+        self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
     }
 
     pub fn execute_async<H: Host + Send>(
@@ -945,7 +976,12 @@ impl DapExecutor {
                     .expect("advice inputs should fit advice map limits");
 
             let resume_ctx = processor.get_initial_resume_context(program)?;
-            let mut wrapper = DapHostWrapper::new(host);
+            // Each pass through this loop starts execution from the beginning, so any
+            // mutations recorded by a previous (restarted) run no longer apply.
+            if let Some(recorder) = self.event_recorder.as_ref() {
+                recorder.clear();
+            }
+            let mut wrapper = DapHostWrapper::new(host, self.event_recorder.clone());
 
             let mut resume_ctx = Some(resume_ctx);
             let mut cycle: usize = 0;
@@ -2097,7 +2133,75 @@ enum StepResult {
 
 #[cfg(test)]
 mod tests {
+    use miden_assembly::DefaultSourceManager;
+    use miden_core::{
+        Felt,
+        events::{EventId, EventName},
+    };
+    use miden_processor::event::EventHandler;
+
     use super::*;
+    use crate::exec::{DebuggerHost, EventMutationRecorder};
+
+    struct PushSeven;
+
+    impl EventHandler for PushSeven {
+        fn on_event(
+            &self,
+            _process: &ProcessorState<'_>,
+        ) -> Result<Vec<AdviceMutation>, EventError> {
+            Ok(vec![AdviceMutation::ExtendStack {
+                values: vec![Felt::from(7u32)],
+            }])
+        }
+    }
+
+    /// The DAP host wrapper is what a client-provided host (e.g. a transaction executor host)
+    /// is driven through; recording must capture the mutations its event handlers produce.
+    #[test]
+    fn dap_host_wrapper_records_event_mutations() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let event_name = "miden-debug::test::dap-record";
+        let event_id = EventId::from_name(event_name).as_u64();
+        let program = miden_assembly::Assembler::new(source_manager.clone())
+            .assemble_program(format!("begin push.{event_id} emit drop adv_push drop end"))
+            .expect("failed to assemble test program");
+
+        let mut host = DebuggerHost::new(source_manager);
+        host.register_event_handler(
+            EventName::from_string(event_name.to_string()),
+            Arc::new(PushSeven),
+        )
+        .expect("failed to register event handler");
+
+        let recorder = EventMutationRecorder::new();
+        let mut wrapper = DapHostWrapper::new(&mut host, Some(recorder.clone()));
+
+        let mut processor = FastProcessor::new_with_options(
+            StackInputs::new(&[]).unwrap(),
+            AdviceInputs::default(),
+            ExecutionOptions::default().with_debugging(true).with_tracing(true),
+        )
+        .expect("invalid inputs");
+        let mut resume_ctx =
+            Some(processor.get_initial_resume_context(&program).expect("invalid program"));
+        while let Some(ctx) = resume_ctx.take() {
+            match poll_immediately(processor.step(&mut wrapper, ctx)).expect("execution failed") {
+                Some(next) => resume_ctx = Some(next),
+                None => break,
+            }
+        }
+
+        assert_eq!(recorder.len(), 1, "expected one recorded entry for the emitted event");
+        let batches = recorder.take();
+        match batches[0].as_slice() {
+            [AdviceMutation::ExtendStack { values }] => {
+                assert_eq!(values.as_slice(), &[Felt::from(7u32)]);
+            }
+            _ => panic!("unexpected mutations recorded"),
+        }
+        assert!(recorder.is_empty(), "take() should leave the recorder empty");
+    }
 
     #[test]
     fn source_paths_match_only_uses_declared_trim_prefixes() {

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io::{BufReader, BufWriter},
     net::TcpListener,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::Rc,
     sync::{
         Arc, OnceLock,
@@ -29,8 +29,8 @@ use miden_processor::{
 };
 
 use super::{
-    EventMutationRecorder, MastForestRecorder, ReplaySnapshot, TraceEvent,
-    state::extract_current_op,
+    EventMutationRecorder, MastForestRecorder, ReplaySnapshot, ReplaySnapshotRecorder,
+    ReplaySnapshotWrite, TraceEvent, state::extract_current_op,
 };
 use crate::debug::{
     DebugVarSnapshot, DebugVarTracker, FormatType, ReadMemoryExpr, resolve_variable_value,
@@ -60,6 +60,8 @@ pub struct DapConfig {
     /// When set, a [ReplaySnapshot] of the session is written to this path once execution
     /// completes. See [DapConfig::record_snapshot].
     snapshot_path: Option<PathBuf>,
+    /// Shared status for the configured replay snapshot write.
+    snapshot_recorder: Option<ReplaySnapshotRecorder>,
 }
 
 impl DapConfig {
@@ -70,6 +72,7 @@ impl DapConfig {
             restart_requested: Arc::new(AtomicBool::new(false)),
             event_recorder: None,
             snapshot_path: None,
+            snapshot_recorder: None,
         }
     }
 
@@ -106,8 +109,9 @@ impl DapConfig {
     /// to re-execute the same program later without the original host (e.g.
     /// `miden-debug --replay <path>`). It always describes the final run, since the recorded state
     /// is reset whenever the session restarts execution from the beginning.
-    pub fn record_snapshot(&mut self, path: impl Into<PathBuf>) {
+    pub fn record_snapshot(&mut self, path: impl Into<PathBuf>) -> ReplaySnapshotRecorder {
         self.snapshot_path = Some(path.into());
+        self.snapshot_recorder.get_or_insert_with(ReplaySnapshotRecorder::new).clone()
     }
 
     /// Returns `true` if the server has signalled a Phase 2 restart.
@@ -1261,14 +1265,16 @@ impl DapExecutor {
                                 server.send_event(Event::Terminated(None)).ok();
                                 // Capture the failed run so it can still be replayed offline.
                                 if let Some(path) = self.config.snapshot_path.as_ref() {
-                                    write_replay_snapshot(
+                                    write_replay_snapshot(ReplaySnapshotWriteContext {
                                         path,
-                                        self.event_recorder.as_ref(),
-                                        self.forest_recorder.as_ref(),
+                                        snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                                        event_recorder: self.event_recorder.as_ref(),
+                                        forest_recorder: self.forest_recorder.as_ref(),
                                         program,
                                         stack_inputs,
-                                        &advice_inputs,
-                                    );
+                                        advice_inputs: &advice_inputs,
+                                        options,
+                                    });
                                 }
                                 return Err(e);
                             }
@@ -1326,14 +1332,16 @@ impl DapExecutor {
                                 server.send_event(Event::Terminated(None)).ok();
                                 // Capture the failed run so it can still be replayed offline.
                                 if let Some(path) = self.config.snapshot_path.as_ref() {
-                                    write_replay_snapshot(
+                                    write_replay_snapshot(ReplaySnapshotWriteContext {
                                         path,
-                                        self.event_recorder.as_ref(),
-                                        self.forest_recorder.as_ref(),
+                                        snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                                        event_recorder: self.event_recorder.as_ref(),
+                                        forest_recorder: self.forest_recorder.as_ref(),
                                         program,
                                         stack_inputs,
-                                        &advice_inputs,
-                                    );
+                                        advice_inputs: &advice_inputs,
+                                        options,
+                                    });
                                 }
                                 return Err(e);
                             }
@@ -1373,14 +1381,16 @@ impl DapExecutor {
                                 server.send_event(Event::Terminated(None)).ok();
                                 // Capture the failed run so it can still be replayed offline.
                                 if let Some(path) = self.config.snapshot_path.as_ref() {
-                                    write_replay_snapshot(
+                                    write_replay_snapshot(ReplaySnapshotWriteContext {
                                         path,
-                                        self.event_recorder.as_ref(),
-                                        self.forest_recorder.as_ref(),
+                                        snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                                        event_recorder: self.event_recorder.as_ref(),
+                                        forest_recorder: self.forest_recorder.as_ref(),
                                         program,
                                         stack_inputs,
-                                        &advice_inputs,
-                                    );
+                                        advice_inputs: &advice_inputs,
+                                        options,
+                                    });
                                 }
                                 return Err(e);
                             }
@@ -1420,14 +1430,16 @@ impl DapExecutor {
                                 server.send_event(Event::Terminated(None)).ok();
                                 // Capture the failed run so it can still be replayed offline.
                                 if let Some(path) = self.config.snapshot_path.as_ref() {
-                                    write_replay_snapshot(
+                                    write_replay_snapshot(ReplaySnapshotWriteContext {
                                         path,
-                                        self.event_recorder.as_ref(),
-                                        self.forest_recorder.as_ref(),
+                                        snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                                        event_recorder: self.event_recorder.as_ref(),
+                                        forest_recorder: self.forest_recorder.as_ref(),
                                         program,
                                         stack_inputs,
-                                        &advice_inputs,
-                                    );
+                                        advice_inputs: &advice_inputs,
+                                        options,
+                                    });
                                 }
                                 return Err(e);
                             }
@@ -1853,14 +1865,16 @@ impl DapExecutor {
                         Err(e) => {
                             // Capture the run up to the failure so it can still be replayed.
                             if let Some(path) = self.config.snapshot_path.as_ref() {
-                                write_replay_snapshot(
+                                write_replay_snapshot(ReplaySnapshotWriteContext {
                                     path,
-                                    self.event_recorder.as_ref(),
-                                    self.forest_recorder.as_ref(),
+                                    snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                                    event_recorder: self.event_recorder.as_ref(),
+                                    forest_recorder: self.forest_recorder.as_ref(),
                                     program,
                                     stack_inputs,
-                                    &advice_inputs,
-                                );
+                                    advice_inputs: &advice_inputs,
+                                    options,
+                                });
                             }
                             return Err(e);
                         }
@@ -1871,14 +1885,16 @@ impl DapExecutor {
             // If a snapshot path is configured, persist a self-contained replay snapshot of this
             // (final) run: program, inputs, resolved forests, and the recorded event log.
             if let Some(path) = self.config.snapshot_path.as_ref() {
-                write_replay_snapshot(
+                write_replay_snapshot(ReplaySnapshotWriteContext {
                     path,
-                    self.event_recorder.as_ref(),
-                    self.forest_recorder.as_ref(),
+                    snapshot_recorder: self.config.snapshot_recorder.as_ref(),
+                    event_recorder: self.event_recorder.as_ref(),
+                    forest_recorder: self.forest_recorder.as_ref(),
                     program,
                     stack_inputs,
-                    &advice_inputs,
-                );
+                    advice_inputs: &advice_inputs,
+                    options,
+                });
             }
 
             // Build ExecutionOutput from the processor's final state.
@@ -1903,31 +1919,52 @@ impl DapExecutor {
 /// reads the shared event recorder afterwards — e.g. an embedder reporting how many mutation sets
 /// were recorded — still sees the full log. Called on every terminal outcome, clean exit or a
 /// failed step, so a failing transaction is captured and replayable too.
-fn write_replay_snapshot(
-    path: &std::path::Path,
-    event_recorder: Option<&EventMutationRecorder>,
-    forest_recorder: Option<&MastForestRecorder>,
-    program: &Program,
+struct ReplaySnapshotWriteContext<'a> {
+    path: &'a Path,
+    snapshot_recorder: Option<&'a ReplaySnapshotRecorder>,
+    event_recorder: Option<&'a EventMutationRecorder>,
+    forest_recorder: Option<&'a MastForestRecorder>,
+    program: &'a Program,
     stack_inputs: StackInputs,
-    advice_inputs: &AdviceInputs,
-) {
-    let event_log = event_recorder.map(EventMutationRecorder::snapshot).unwrap_or_default();
-    let mast_forests = forest_recorder.map(MastForestRecorder::snapshot).unwrap_or_default();
+    advice_inputs: &'a AdviceInputs,
+    options: ExecutionOptions,
+}
+
+fn write_replay_snapshot(context: ReplaySnapshotWriteContext<'_>) {
+    let event_log = context.event_recorder.map(EventMutationRecorder::snapshot).unwrap_or_default();
+    let mast_forests =
+        context.forest_recorder.map(MastForestRecorder::snapshot).unwrap_or_default();
     let snapshot = ReplaySnapshot {
-        program: program.clone(),
-        stack_inputs,
-        advice_inputs: advice_inputs.clone(),
+        program: context.program.clone(),
+        stack_inputs: context.stack_inputs,
+        advice_inputs: context.advice_inputs.clone(),
+        options: context.options,
         mast_forests,
         event_log,
     };
-    match snapshot.write_to_file(path) {
-        Ok(()) => eprintln!(
-            "Wrote replay snapshot ({} event(s), {} forest(s)) to {}",
-            snapshot.event_log.len(),
-            snapshot.mast_forests.len(),
-            path.display()
-        ),
-        Err(err) => eprintln!("Failed to write replay snapshot to {}: {err}", path.display()),
+    match snapshot.write_to_file(context.path) {
+        Ok(()) => {
+            let write = ReplaySnapshotWrite {
+                path: context.path.to_path_buf(),
+                event_count: snapshot.event_log.len(),
+                forest_count: snapshot.mast_forests.len(),
+            };
+            if let Some(recorder) = context.snapshot_recorder {
+                recorder.record_success(write.clone());
+            }
+            eprintln!(
+                "Wrote replay snapshot ({} event(s), {} forest(s)) to {}",
+                write.event_count,
+                write.forest_count,
+                write.path.display()
+            );
+        }
+        Err(err) => {
+            if let Some(recorder) = context.snapshot_recorder {
+                recorder.record_error(context.path.to_path_buf(), err.to_string());
+            }
+            eprintln!("Failed to write replay snapshot to {}: {err}", context.path.display());
+        }
     }
 }
 

--- a/crates/engine/src/exec/dap.rs
+++ b/crates/engine/src/exec/dap.rs
@@ -51,6 +51,9 @@ pub struct DapConfig {
     /// Shared flag: set by the server when a Phase 2 restart (terminate-and-reconnect) is
     /// requested, read by the caller to decide whether to recompile and re-enter.
     restart_requested: Arc<AtomicBool>,
+    /// When set, the advice mutations produced by the host's event handlers are recorded into
+    /// this shared log during the session. See [DapConfig::record_event_mutations].
+    event_recorder: Option<EventMutationRecorder>,
 }
 
 impl DapConfig {
@@ -59,6 +62,7 @@ impl DapConfig {
             listen_addr: listen_addr.into(),
             source_path_prefixes: Vec::new(),
             restart_requested: Arc::new(AtomicBool::new(false)),
+            event_recorder: None,
         }
     }
 
@@ -69,6 +73,23 @@ impl DapConfig {
             .filter(|prefix| !prefix.is_empty())
             .collect();
         self
+    }
+
+    /// Record the advice mutations produced by the host's event handlers during the session.
+    ///
+    /// Returns a shared handle that outlives the executor: the [DapExecutor] is constructed
+    /// internally (e.g. by a transaction executor) from the global configuration and consumed
+    /// by execution, so the handle obtained here — by whoever installs the configuration via
+    /// [DapConfig::set_global] — is how the recorded log is read once execution returns.
+    ///
+    /// One entry is recorded per `on_event` invocation, in execution order, including empty
+    /// mutation sets. The log always describes the final run (it is cleared whenever the
+    /// session restarts execution from the beginning) and can be fed into an event-replay
+    /// debugging session (e.g. `Executor::into_debug_with_replay` or
+    /// `State::new_for_transaction`) to re-execute the same program without the original
+    /// host's event handlers.
+    pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
+        self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
     }
 
     /// Returns `true` if the server has signalled a Phase 2 restart.
@@ -862,25 +883,30 @@ impl DapExecutor {
         options: ExecutionOptions,
     ) -> Self {
         let config = DAP_CONFIG.get().cloned().unwrap_or_default();
+        let event_recorder = config.event_recorder.clone();
         DapExecutor {
             stack_inputs,
             advice_inputs,
             options,
             config,
-            event_recorder: None,
+            event_recorder,
         }
     }
 
     /// Record the advice mutations produced by each event handler invocation of the wrapped
     /// host during execution.
     ///
-    /// Returns a handle to the shared log. One entry is recorded per `on_event` invocation, in
-    /// execution order, including empty mutation sets, so the log can be fed directly into an
-    /// event replay queue (e.g. `Executor::into_debug_with_replay` or
-    /// `State::new_for_transaction`) to debug the same execution later without access to the
-    /// original host. The log is cleared automatically whenever the DAP session restarts
-    /// execution from the beginning, so after execution completes it always describes the final
-    /// run.
+    /// Returns a handle to the shared log. When recording was enabled on the installed
+    /// [DapConfig] (see [DapConfig::record_event_mutations]), this is the same log, so
+    /// embedders that never see the executor instance read the recording through their config
+    /// handle instead.
+    ///
+    /// One entry is recorded per `on_event` invocation, in execution order, including empty
+    /// mutation sets, so the log can be fed directly into an event replay queue (e.g.
+    /// `Executor::into_debug_with_replay` or `State::new_for_transaction`) to debug the same
+    /// execution later without access to the original host. The log is cleared automatically
+    /// whenever the DAP session restarts execution from the beginning, so after execution
+    /// completes it always describes the final run.
     pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
         self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
     }
@@ -2201,6 +2227,29 @@ mod tests {
             _ => panic!("unexpected mutations recorded"),
         }
         assert!(recorder.is_empty(), "take() should leave the recorder empty");
+    }
+
+    /// The executor is constructed internally (e.g. by a transaction executor) and consumed by
+    /// execution, so embedders read the recording through the handle obtained from the global
+    /// [DapConfig] before execution: both must share one log.
+    #[test]
+    fn dap_config_recorder_is_shared_with_the_executor() {
+        let mut config = DapConfig::new("127.0.0.1:0");
+        let config_handle = config.record_event_mutations();
+        DapConfig::set_global(config);
+
+        let mut executor = DapExecutor::new(
+            StackInputs::new(&[]).unwrap(),
+            AdviceInputs::default(),
+            ExecutionOptions::default(),
+        );
+        executor.record_event_mutations().record(vec![]);
+
+        assert_eq!(
+            config_handle.len(),
+            1,
+            "recording through the executor must be visible through the config handle"
+        );
     }
 
     #[test]

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -25,8 +25,8 @@ use miden_processor::{
 };
 
 use super::{
-    DebugExecutor, DebuggerHost, EventMutationRecorder, ExecutionConfig, ExecutionTrace,
-    TraceEvent, query::read_memory_bytes, trace_event::TRACE_PRINT_LN,
+    DebugExecutor, DebuggerHost, ExecutionConfig, ExecutionTrace, TraceEvent,
+    query::read_memory_bytes, trace_event::TRACE_PRINT_LN,
 };
 use crate::{
     debug::{CallStack, DebugVarTracker, NativePtr},
@@ -54,7 +54,7 @@ pub struct Executor {
     libraries: Vec<Arc<Library>>,
     event_handlers: Vec<(EventName, Arc<dyn EventHandler>)>,
     dependency_resolver: BTreeMap<Word, Arc<Library>>,
-    event_recorder: Option<EventMutationRecorder>,
+    record_event_mutations: bool,
 }
 impl Executor {
     /// Construct an executor with the given arguments on the operand stack
@@ -86,7 +86,7 @@ impl Executor {
             libraries: Default::default(),
             event_handlers: Default::default(),
             dependency_resolver,
-            event_recorder: None,
+            record_event_mutations: false,
         }
     }
 
@@ -141,17 +141,19 @@ impl Executor {
         self
     }
 
-    /// Record the advice mutations produced by each event handler invocation.
+    /// Record the advice mutations produced by each event handler invocation during execution.
     ///
-    /// Returns a handle to the shared log; the same handle keeps accumulating entries during
-    /// execution and can be read after the program completes. The recorded log can be fed back
-    /// into [Executor::into_debug_with_replay] to debug the same execution later without the
-    /// original event handlers (e.g. transaction debugging with event replay).
+    /// Recording is a private detail of the debug host created by [Executor::into_debug]: once
+    /// the program completes, take the log via [DebuggerHost::take_recorded_event_mutations] on
+    /// the [DebugExecutor]'s host, and feed it back into [Executor::into_debug_with_replay] to
+    /// debug the same execution later without the original event handlers (e.g. transaction
+    /// debugging with event replay).
     ///
     /// Mutations are only recorded for live event handling; nothing is recorded while an event
     /// replay queue is being consumed.
-    pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
-        self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
+    pub fn with_event_advice_mutations_recording(&mut self) -> &mut Self {
+        self.record_event_mutations = true;
+        self
     }
 
     /// Register a VM event handler to be available during execution.
@@ -181,8 +183,8 @@ impl Executor {
             host.register_event_handler(event, handler)
                 .expect("failed to register debug executor event handler");
         }
-        if let Some(recorder) = self.event_recorder.take() {
-            host.set_event_recorder(recorder);
+        if self.record_event_mutations {
+            host = host.with_event_advice_mutations_recording();
         }
 
         let trace_events: Rc<RefCell<BTreeMap<RowIndex, TraceEvent>>> = Rc::new(Default::default());
@@ -620,14 +622,20 @@ mod tests {
                 }),
             )
             .expect("failed to register event handler");
-        let recorder = executor.record_event_mutations();
+        executor.with_event_advice_mutations_recording();
 
-        let trace = executor.execute(&program, source_manager.clone());
-        let recorded_result: u32 = trace.parse_result().expect("invalid result");
+        // Run to completion through the debug executor: recording is an internal detail of its
+        // host, and the log is taken from the host once execution finishes.
+        let mut debug_executor = executor.into_debug(&program, source_manager.clone());
+        while !debug_executor.stopped {
+            debug_executor.step().expect("recording step failed");
+        }
+        let recorded = debug_executor.host.take_recorded_event_mutations();
+        let recorded_result: u32 =
+            debug_executor.into_execution_trace().parse_result().expect("invalid result");
         assert_eq!(recorded_result, 201);
 
-        assert_eq!(recorder.len(), 2, "expected one recorded entry per emit");
-        let recorded = recorder.snapshot();
+        assert_eq!(recorded.len(), 2, "expected one recorded entry per emit");
         for (index, batch) in recorded.iter().enumerate() {
             match batch.as_slice() {
                 [AdviceMutation::ExtendStack { values }] => {
@@ -644,7 +652,7 @@ mod tests {
             &program,
             source_manager,
             Vec::new(),
-            recorder.take().into(),
+            recorded.into(),
         );
         while !debug_executor.stopped {
             debug_executor.step().expect("replay step failed");

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -697,7 +697,8 @@ mod tests {
         let event_name = "miden-debug::test::snapshot-replay";
         let event_id = EventId::from_name(event_name).as_u64();
         let source = format!(
-            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add add end"
+            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add add \
+             end"
         );
         let program = miden_assembly::Assembler::new(source_manager.clone())
             .assemble_program(source)

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -663,4 +663,92 @@ mod tests {
             .expect("invalid replay result");
         assert_eq!(replayed_result, recorded_result);
     }
+
+    /// A recorded execution serialized into a [ReplaySnapshot](crate::exec::ReplaySnapshot) and
+    /// read back from bytes replays to the same result — the offline record→replay path, end to
+    /// end, exactly what `miden-debug --replay <snapshot>` drives.
+    #[test]
+    fn replays_from_a_serialized_snapshot() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use miden_assembly::DefaultSourceManager;
+        use miden_core::events::EventId;
+        use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+
+        use crate::exec::ReplaySnapshot;
+
+        struct CountingHandler {
+            calls: AtomicU64,
+        }
+
+        impl EventHandler for CountingHandler {
+            fn on_event(
+                &self,
+                _process: &ProcessorState<'_>,
+            ) -> Result<Vec<AdviceMutation>, EventError> {
+                let call = self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![AdviceMutation::ExtendStack {
+                    values: vec![Felt::from(100u32 + call as u32)],
+                }])
+            }
+        }
+
+        let source_manager: Arc<DefaultSourceManager> = Arc::new(DefaultSourceManager::default());
+        let event_name = "miden-debug::test::snapshot-replay";
+        let event_id = EventId::from_name(event_name).as_u64();
+        let source = format!(
+            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add swap \
+             drop end"
+        );
+        let program = miden_assembly::Assembler::new(source_manager.clone())
+            .assemble_program(source)
+            .expect("failed to assemble test program");
+
+        // Record the event mutations by running to completion with a live handler.
+        let mut executor = Executor::new(Vec::new());
+        executor
+            .register_event_handler(
+                EventName::from_string(event_name.to_string()),
+                Arc::new(CountingHandler {
+                    calls: AtomicU64::new(0),
+                }),
+            )
+            .expect("failed to register event handler");
+        executor.with_event_advice_mutations_recording();
+        let mut debug_executor = executor.into_debug(&program, source_manager.clone());
+        while !debug_executor.stopped {
+            debug_executor.step().expect("recording step failed");
+        }
+        let event_log = debug_executor.host.take_recorded_event_mutations();
+        let recorded_result: u32 =
+            debug_executor.into_execution_trace().parse_result().expect("invalid result");
+
+        // Persist the recording as a snapshot and read it back from its serialized bytes.
+        let snapshot = ReplaySnapshot {
+            program: program.clone(),
+            stack_inputs: StackInputs::default(),
+            advice_inputs: AdviceInputs::default(),
+            mast_forests: vec![program.mast_forest().clone()],
+            event_log,
+        };
+        let restored = ReplaySnapshot::read_from_bytes(&snapshot.to_bytes())
+            .expect("snapshot failed to deserialize");
+
+        // Replay from the deserialized snapshot, with no event handlers registered.
+        let mut debug_executor = Executor::new(Vec::new()).into_debug_with_replay(
+            &restored.program,
+            source_manager,
+            restored.mast_forests,
+            restored.event_log.into(),
+        );
+        while !debug_executor.stopped {
+            debug_executor.step().expect("replay step failed");
+        }
+        let replayed_result: u32 = debug_executor
+            .into_execution_trace()
+            .parse_result()
+            .expect("invalid replay result");
+        assert_eq!(replayed_result, recorded_result);
+        assert_eq!(replayed_result, 201);
+    }
 }

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -25,8 +25,8 @@ use miden_processor::{
 };
 
 use super::{
-    DebugExecutor, DebuggerHost, ExecutionConfig, ExecutionTrace, TraceEvent,
-    query::read_memory_bytes, trace_event::TRACE_PRINT_LN,
+    DebugExecutor, DebuggerHost, EventMutationRecorder, ExecutionConfig, ExecutionTrace,
+    TraceEvent, query::read_memory_bytes, trace_event::TRACE_PRINT_LN,
 };
 use crate::{
     debug::{CallStack, DebugVarTracker, NativePtr},
@@ -54,6 +54,7 @@ pub struct Executor {
     libraries: Vec<Arc<Library>>,
     event_handlers: Vec<(EventName, Arc<dyn EventHandler>)>,
     dependency_resolver: BTreeMap<Word, Arc<Library>>,
+    event_recorder: Option<EventMutationRecorder>,
 }
 impl Executor {
     /// Construct an executor with the given arguments on the operand stack
@@ -85,6 +86,7 @@ impl Executor {
             libraries: Default::default(),
             event_handlers: Default::default(),
             dependency_resolver,
+            event_recorder: None,
         }
     }
 
@@ -139,6 +141,19 @@ impl Executor {
         self
     }
 
+    /// Record the advice mutations produced by each event handler invocation.
+    ///
+    /// Returns a handle to the shared log; the same handle keeps accumulating entries during
+    /// execution and can be read after the program completes. The recorded log can be fed back
+    /// into [Executor::into_debug_with_replay] to debug the same execution later without the
+    /// original event handlers (e.g. transaction debugging with event replay).
+    ///
+    /// Mutations are only recorded for live event handling; nothing is recorded while an event
+    /// replay queue is being consumed.
+    pub fn record_event_mutations(&mut self) -> EventMutationRecorder {
+        self.event_recorder.get_or_insert_with(EventMutationRecorder::new).clone()
+    }
+
     /// Register a VM event handler to be available during execution.
     pub fn register_event_handler(
         &mut self,
@@ -165,6 +180,9 @@ impl Executor {
         for (event, handler) in core::mem::take(&mut self.event_handlers) {
             host.register_event_handler(event, handler)
                 .expect("failed to register debug executor event handler");
+        }
+        if let Some(recorder) = self.event_recorder.take() {
+            host.set_event_recorder(recorder);
         }
 
         let trace_events: Rc<RefCell<BTreeMap<RowIndex, TraceEvent>>> = Rc::new(Default::default());
@@ -552,5 +570,89 @@ mod tests {
         assert!(message.contains("missing dependency 'miden-core'"));
         assert!(message.contains("-l miden-core"));
         assert!(message.contains("-l <path-to-miden-core.masp>"));
+    }
+
+    /// One entry per `on_event` invocation, in execution order, and the recorded log replays to
+    /// an identical result without the original event handlers.
+    #[test]
+    fn records_event_mutations_and_replays_them() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use miden_assembly::DefaultSourceManager;
+        use miden_core::events::EventId;
+        use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+
+        struct CountingHandler {
+            calls: AtomicU64,
+        }
+
+        impl EventHandler for CountingHandler {
+            fn on_event(
+                &self,
+                _process: &ProcessorState<'_>,
+            ) -> Result<Vec<AdviceMutation>, EventError> {
+                let call = self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![AdviceMutation::ExtendStack {
+                    values: vec![Felt::from(100u32 + call as u32)],
+                }])
+            }
+        }
+
+        let source_manager: Arc<DefaultSourceManager> = Arc::new(DefaultSourceManager::default());
+        let event_name = "miden-debug::test::record-replay";
+        let event_id = EventId::from_name(event_name).as_u64();
+        // Each emit invokes the handler, which pushes one value onto the advice stack;
+        // adv_push moves it to the operand stack, and the sum of both values is the result.
+        let source = format!(
+            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add swap \
+             drop end"
+        );
+        let program = miden_assembly::Assembler::new(source_manager.clone())
+            .assemble_program(source)
+            .expect("failed to assemble test program");
+
+        let mut executor = Executor::new(Vec::new());
+        executor
+            .register_event_handler(
+                EventName::from_string(event_name.to_string()),
+                Arc::new(CountingHandler {
+                    calls: AtomicU64::new(0),
+                }),
+            )
+            .expect("failed to register event handler");
+        let recorder = executor.record_event_mutations();
+
+        let trace = executor.execute(&program, source_manager.clone());
+        let recorded_result: u32 = trace.parse_result().expect("invalid result");
+        assert_eq!(recorded_result, 201);
+
+        assert_eq!(recorder.len(), 2, "expected one recorded entry per emit");
+        let recorded = recorder.snapshot();
+        for (index, batch) in recorded.iter().enumerate() {
+            match batch.as_slice() {
+                [AdviceMutation::ExtendStack { values }] => {
+                    assert_eq!(values.as_slice(), &[Felt::from(100u32 + index as u32)]);
+                }
+                _ => panic!("unexpected mutations recorded for event {index}"),
+            }
+        }
+
+        // Replay the recorded mutations without any event handlers registered: execution must
+        // reach the same result, proving the log is sufficient for event replay.
+        let replay_executor = Executor::new(Vec::new());
+        let mut debug_executor = replay_executor.into_debug_with_replay(
+            &program,
+            source_manager,
+            Vec::new(),
+            recorder.take().into(),
+        );
+        while !debug_executor.stopped {
+            debug_executor.step().expect("replay step failed");
+        }
+        let replayed_result: u32 = debug_executor
+            .into_execution_trace()
+            .parse_result()
+            .expect("invalid replay result");
+        assert_eq!(replayed_result, recorded_result);
     }
 }

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -697,15 +697,21 @@ mod tests {
         let event_name = "miden-debug::test::snapshot-replay";
         let event_id = EventId::from_name(event_name).as_u64();
         let source = format!(
-            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add swap \
-             drop end"
+            "begin push.{event_id} emit drop adv_push push.{event_id} emit drop adv_push add add end"
         );
         let program = miden_assembly::Assembler::new(source_manager.clone())
             .assemble_program(source)
             .expect("failed to assemble test program");
+        let stack_inputs = StackInputs::new(&[Felt::from(7u32)]).unwrap();
+        let advice_inputs = AdviceInputs::default();
+        let options = ExecutionOptions::default().with_debugging(true).with_tracing(true);
 
         // Record the event mutations by running to completion with a live handler.
-        let mut executor = Executor::new(Vec::new());
+        let mut executor = Executor::from_config(ExecutionConfig {
+            inputs: stack_inputs,
+            advice_inputs: advice_inputs.clone(),
+            options,
+        });
         executor
             .register_event_handler(
                 EventName::from_string(event_name.to_string()),
@@ -726,8 +732,9 @@ mod tests {
         // Persist the recording as a snapshot and read it back from its serialized bytes.
         let snapshot = ReplaySnapshot {
             program: program.clone(),
-            stack_inputs: StackInputs::default(),
-            advice_inputs: AdviceInputs::default(),
+            stack_inputs,
+            advice_inputs,
+            options,
             mast_forests: vec![program.mast_forest().clone()],
             event_log,
         };
@@ -735,7 +742,12 @@ mod tests {
             .expect("snapshot failed to deserialize");
 
         // Replay from the deserialized snapshot, with no event handlers registered.
-        let mut debug_executor = Executor::new(Vec::new()).into_debug_with_replay(
+        let replay_executor = Executor::from_config(ExecutionConfig {
+            inputs: restored.stack_inputs,
+            advice_inputs: restored.advice_inputs,
+            options: restored.options,
+        });
+        let mut debug_executor = replay_executor.into_debug_with_replay(
             &restored.program,
             source_manager,
             restored.mast_forests,
@@ -749,6 +761,6 @@ mod tests {
             .parse_result()
             .expect("invalid replay result");
         assert_eq!(replayed_result, recorded_result);
-        assert_eq!(replayed_result, 201);
+        assert_eq!(replayed_result, 208);
     }
 }

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     num::NonZeroU32,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use miden_assembly::SourceManager;
@@ -18,90 +18,10 @@ use miden_processor::{
     mast::MastForest,
 };
 
-use super::{TraceEvent, TraceHandler};
-
-/// Clone a single [AdviceMutation].
-///
-/// [AdviceMutation] does not implement [Clone] upstream, so recording and replaying event
-/// mutations requires reconstructing each variant by hand.
-pub fn clone_advice_mutation(mutation: &AdviceMutation) -> AdviceMutation {
-    match mutation {
-        AdviceMutation::ExtendStack { values } => AdviceMutation::ExtendStack {
-            values: values.clone(),
-        },
-        AdviceMutation::ExtendMap { other } => AdviceMutation::ExtendMap {
-            other: other.clone(),
-        },
-        AdviceMutation::ExtendMerkleStore { infos } => AdviceMutation::ExtendMerkleStore {
-            infos: infos.clone(),
-        },
-        AdviceMutation::ExtendPrecompileRequests { data } => {
-            AdviceMutation::ExtendPrecompileRequests { data: data.clone() }
-        }
-    }
-}
-
-/// Clone a batch of [AdviceMutation]s. See [clone_advice_mutation].
-pub fn clone_advice_mutations(mutations: &[AdviceMutation]) -> Vec<AdviceMutation> {
-    mutations.iter().map(clone_advice_mutation).collect()
-}
-
-/// A shared, cloneable log of the advice mutations produced by event handlers.
-///
-/// One entry is recorded per `on_event` invocation, in execution order, **including empty
-/// mutation sets**: event replay pops exactly one entry per event, so the log must stay aligned
-/// with the event stream of the recorded execution.
-///
-/// Attach a recorder to a live execution (see [DebuggerHost::set_event_recorder] or
-/// `DapExecutor::record_event_mutations`), run the program to completion, and feed the recorded
-/// log into [DebuggerHost::set_event_replay] (or `Executor::into_debug_with_replay`) to debug
-/// the same execution later without access to the original host's event handlers.
-#[derive(Clone, Default)]
-pub struct EventMutationRecorder {
-    log: Arc<Mutex<Vec<Vec<AdviceMutation>>>>,
-}
-
-impl EventMutationRecorder {
-    /// Create a new, empty recorder.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the recorded mutation batches, leaving the recorder empty.
-    pub fn take(&self) -> Vec<Vec<AdviceMutation>> {
-        core::mem::take(&mut *self.log.lock().expect("event mutation log poisoned"))
-    }
-
-    /// Returns a copy of the recorded mutation batches, leaving the recorder intact.
-    pub fn snapshot(&self) -> Vec<Vec<AdviceMutation>> {
-        self.log
-            .lock()
-            .expect("event mutation log poisoned")
-            .iter()
-            .map(|batch| clone_advice_mutations(batch))
-            .collect()
-    }
-
-    /// The number of `on_event` invocations recorded so far.
-    pub fn len(&self) -> usize {
-        self.log.lock().expect("event mutation log poisoned").len()
-    }
-
-    /// Returns true if no `on_event` invocations have been recorded.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Record the mutations produced by one `on_event` invocation.
-    pub(crate) fn record(&self, mutations: Vec<AdviceMutation>) {
-        self.log.lock().expect("event mutation log poisoned").push(mutations);
-    }
-
-    /// Discard everything recorded so far, e.g. when execution restarts from the beginning.
-    pub(crate) fn clear(&self) {
-        self.log.lock().expect("event mutation log poisoned").clear();
-    }
-}
+use super::{
+    TraceEvent, TraceHandler,
+    advice::{EventMutationRecorder, clone_advice_mutations},
+};
 
 /// This is an implementation of [Host] which is essentially [miden_processor::DefaultHost],
 /// but extended with additional functionality for debugging, in particular it manages trace

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -18,10 +18,7 @@ use miden_processor::{
     mast::MastForest,
 };
 
-use super::{
-    TraceEvent, TraceHandler,
-    advice::{EventMutationRecorder, clone_advice_mutations},
-};
+use super::{TraceEvent, TraceHandler, advice::clone_advice_mutations};
 
 /// This is an implementation of [Host] which is essentially [miden_processor::DefaultHost],
 /// but extended with additional functionality for debugging, in particular it manages trace
@@ -33,7 +30,7 @@ pub struct DebuggerHost<S: SourceManager + ?Sized> {
     on_assert_failed: Option<Box<TraceHandler>>,
     source_manager: Arc<S>,
     event_replay: VecDeque<Vec<AdviceMutation>>,
-    event_recorder: Option<EventMutationRecorder>,
+    event_recording: Option<Vec<Vec<AdviceMutation>>>,
 }
 impl<S> DebuggerHost<S>
 where
@@ -48,7 +45,7 @@ where
             on_assert_failed: None,
             source_manager,
             event_replay: VecDeque::new(),
-            event_recorder: None,
+            event_recording: None,
         }
     }
 
@@ -61,12 +58,26 @@ where
         self.event_replay = events;
     }
 
-    /// Record the advice mutations produced by each event handler invocation into `recorder`.
+    /// Record the advice mutations produced by each event handler invocation.
+    ///
+    /// One entry is recorded per `on_event` invocation, in execution order, **including empty
+    /// mutation sets**, so the recorded log can be fed directly back into
+    /// [DebuggerHost::set_event_replay] to replay this execution later. Take the log with
+    /// [DebuggerHost::take_recorded_event_mutations] once execution completes.
     ///
     /// Mutations are only recorded for live event handling; nothing is recorded while an event
     /// replay queue is being consumed.
-    pub fn set_event_recorder(&mut self, recorder: EventMutationRecorder) {
-        self.event_recorder = Some(recorder);
+    pub fn with_event_advice_mutations_recording(mut self) -> Self {
+        self.event_recording = Some(Vec::new());
+        self
+    }
+
+    /// Returns the advice mutations recorded so far, leaving the recording empty.
+    ///
+    /// Returns an empty log when recording was not enabled via
+    /// [DebuggerHost::with_event_advice_mutations_recording].
+    pub fn take_recorded_event_mutations(&mut self) -> Vec<Vec<AdviceMutation>> {
+        self.event_recording.as_mut().map(core::mem::take).unwrap_or_default()
     }
 
     /// Register a trace handler for `event`
@@ -175,8 +186,8 @@ where
             }
             Err(err) => Err(err),
         };
-        if let (Some(recorder), Ok(mutations)) = (&self.event_recorder, &result) {
-            recorder.record(clone_advice_mutations(mutations));
+        if let (Some(log), Ok(mutations)) = (self.event_recording.as_mut(), &result) {
+            log.push(clone_advice_mutations(mutations));
         }
         std::future::ready(result)
     }

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     num::NonZeroU32,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use miden_assembly::SourceManager;
@@ -20,6 +20,89 @@ use miden_processor::{
 
 use super::{TraceEvent, TraceHandler};
 
+/// Clone a single [AdviceMutation].
+///
+/// [AdviceMutation] does not implement [Clone] upstream, so recording and replaying event
+/// mutations requires reconstructing each variant by hand.
+pub fn clone_advice_mutation(mutation: &AdviceMutation) -> AdviceMutation {
+    match mutation {
+        AdviceMutation::ExtendStack { values } => AdviceMutation::ExtendStack {
+            values: values.clone(),
+        },
+        AdviceMutation::ExtendMap { other } => AdviceMutation::ExtendMap {
+            other: other.clone(),
+        },
+        AdviceMutation::ExtendMerkleStore { infos } => AdviceMutation::ExtendMerkleStore {
+            infos: infos.clone(),
+        },
+        AdviceMutation::ExtendPrecompileRequests { data } => {
+            AdviceMutation::ExtendPrecompileRequests { data: data.clone() }
+        }
+    }
+}
+
+/// Clone a batch of [AdviceMutation]s. See [clone_advice_mutation].
+pub fn clone_advice_mutations(mutations: &[AdviceMutation]) -> Vec<AdviceMutation> {
+    mutations.iter().map(clone_advice_mutation).collect()
+}
+
+/// A shared, cloneable log of the advice mutations produced by event handlers.
+///
+/// One entry is recorded per `on_event` invocation, in execution order, **including empty
+/// mutation sets**: event replay pops exactly one entry per event, so the log must stay aligned
+/// with the event stream of the recorded execution.
+///
+/// Attach a recorder to a live execution (see [DebuggerHost::set_event_recorder] or
+/// `DapExecutor::record_event_mutations`), run the program to completion, and feed the recorded
+/// log into [DebuggerHost::set_event_replay] (or `Executor::into_debug_with_replay`) to debug
+/// the same execution later without access to the original host's event handlers.
+#[derive(Clone, Default)]
+pub struct EventMutationRecorder {
+    log: Arc<Mutex<Vec<Vec<AdviceMutation>>>>,
+}
+
+impl EventMutationRecorder {
+    /// Create a new, empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the recorded mutation batches, leaving the recorder empty.
+    pub fn take(&self) -> Vec<Vec<AdviceMutation>> {
+        core::mem::take(&mut *self.log.lock().expect("event mutation log poisoned"))
+    }
+
+    /// Returns a copy of the recorded mutation batches, leaving the recorder intact.
+    pub fn snapshot(&self) -> Vec<Vec<AdviceMutation>> {
+        self.log
+            .lock()
+            .expect("event mutation log poisoned")
+            .iter()
+            .map(|batch| clone_advice_mutations(batch))
+            .collect()
+    }
+
+    /// The number of `on_event` invocations recorded so far.
+    pub fn len(&self) -> usize {
+        self.log.lock().expect("event mutation log poisoned").len()
+    }
+
+    /// Returns true if no `on_event` invocations have been recorded.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Record the mutations produced by one `on_event` invocation.
+    pub(crate) fn record(&self, mutations: Vec<AdviceMutation>) {
+        self.log.lock().expect("event mutation log poisoned").push(mutations);
+    }
+
+    /// Discard everything recorded so far, e.g. when execution restarts from the beginning.
+    pub(crate) fn clear(&self) {
+        self.log.lock().expect("event mutation log poisoned").clear();
+    }
+}
+
 /// This is an implementation of [Host] which is essentially [miden_processor::DefaultHost],
 /// but extended with additional functionality for debugging, in particular it manages trace
 /// events that record the entry or exit of a procedure call frame.
@@ -30,6 +113,7 @@ pub struct DebuggerHost<S: SourceManager + ?Sized> {
     on_assert_failed: Option<Box<TraceHandler>>,
     source_manager: Arc<S>,
     event_replay: VecDeque<Vec<AdviceMutation>>,
+    event_recorder: Option<EventMutationRecorder>,
 }
 impl<S> DebuggerHost<S>
 where
@@ -44,6 +128,7 @@ where
             on_assert_failed: None,
             source_manager,
             event_replay: VecDeque::new(),
+            event_recorder: None,
         }
     }
 
@@ -54,6 +139,14 @@ where
     /// were recorded during a prior execution.
     pub fn set_event_replay(&mut self, events: VecDeque<Vec<AdviceMutation>>) {
         self.event_replay = events;
+    }
+
+    /// Record the advice mutations produced by each event handler invocation into `recorder`.
+    ///
+    /// Mutations are only recorded for live event handling; nothing is recorded while an event
+    /// replay queue is being consumed.
+    pub fn set_event_recorder(&mut self, recorder: EventMutationRecorder) {
+        self.event_recorder = Some(recorder);
     }
 
     /// Register a trace handler for `event`
@@ -162,6 +255,9 @@ where
             }
             Err(err) => Err(err),
         };
+        if let (Some(recorder), Ok(mutations)) = (&self.event_recorder, &result) {
+            recorder.record(clone_advice_mutations(mutations));
+        }
         std::future::ready(result)
     }
 }

--- a/crates/engine/src/exec/mod.rs
+++ b/crates/engine/src/exec/mod.rs
@@ -32,7 +32,10 @@ pub use self::{
     executor::Executor,
     host::DebuggerHost,
     query::DebugQuery,
-    snapshot::{MastForestRecorder, ReplaySnapshot, ReplaySnapshotError},
+    snapshot::{
+        MastForestRecorder, ReplaySnapshot, ReplaySnapshotError, ReplaySnapshotRecorder,
+        ReplaySnapshotWrite, ReplaySnapshotWriteError,
+    },
     state::DebugExecutor,
     trace::{ExecutionTrace, TraceHandler},
     trace_event::{TRACE_PRINT_LN, TraceEvent},

--- a/crates/engine/src/exec/mod.rs
+++ b/crates/engine/src/exec/mod.rs
@@ -10,6 +10,7 @@ mod diagnostic;
 mod executor;
 mod host;
 mod query;
+mod snapshot;
 mod state;
 mod trace;
 mod trace_event;
@@ -22,12 +23,16 @@ pub use self::dap_client::{DapClient, DapStopReason, SCOPE_MEMORY, SCOPE_STACK};
 #[cfg(feature = "dap")]
 pub use self::dap_types::{DapUiFrame, DapUiState};
 pub use self::{
-    advice::{EventMutationRecorder, clone_advice_mutation, clone_advice_mutations},
+    advice::{
+        EventMutationRecorder, clone_advice_mutation, clone_advice_mutations, read_advice_mutation,
+        read_event_log, write_advice_mutation, write_event_log,
+    },
     config::ExecutionConfig,
     diagnostic::DiagnosticExecutor,
     executor::Executor,
     host::DebuggerHost,
     query::DebugQuery,
+    snapshot::{MastForestRecorder, ReplaySnapshot, ReplaySnapshotError},
     state::DebugExecutor,
     trace::{ExecutionTrace, TraceHandler},
     trace_event::{TRACE_PRINT_LN, TraceEvent},

--- a/crates/engine/src/exec/mod.rs
+++ b/crates/engine/src/exec/mod.rs
@@ -1,3 +1,4 @@
+mod advice;
 mod config;
 #[cfg(feature = "dap")]
 mod dap;
@@ -21,10 +22,11 @@ pub use self::dap_client::{DapClient, DapStopReason, SCOPE_MEMORY, SCOPE_STACK};
 #[cfg(feature = "dap")]
 pub use self::dap_types::{DapUiFrame, DapUiState};
 pub use self::{
+    advice::{EventMutationRecorder, clone_advice_mutation, clone_advice_mutations},
     config::ExecutionConfig,
     diagnostic::DiagnosticExecutor,
     executor::Executor,
-    host::{DebuggerHost, EventMutationRecorder, clone_advice_mutation, clone_advice_mutations},
+    host::DebuggerHost,
     query::DebugQuery,
     state::DebugExecutor,
     trace::{ExecutionTrace, TraceHandler},

--- a/crates/engine/src/exec/mod.rs
+++ b/crates/engine/src/exec/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     config::ExecutionConfig,
     diagnostic::DiagnosticExecutor,
     executor::Executor,
-    host::DebuggerHost,
+    host::{DebuggerHost, EventMutationRecorder, clone_advice_mutation, clone_advice_mutations},
     query::DebugQuery,
     state::DebugExecutor,
     trace::{ExecutionTrace, TraceHandler},

--- a/crates/engine/src/exec/snapshot.rs
+++ b/crates/engine/src/exec/snapshot.rs
@@ -10,7 +10,7 @@
 //! `State::new_for_transaction`).
 
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -19,7 +19,10 @@ use miden_core::{
     program::{Program, StackInputs},
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
-use miden_processor::advice::{AdviceInputs, AdviceMutation};
+use miden_processor::{
+    ExecutionOptions,
+    advice::{AdviceInputs, AdviceMutation},
+};
 
 use super::advice::{read_event_log, write_event_log};
 
@@ -59,6 +62,51 @@ impl MastForestRecorder {
     }
 }
 
+/// Successful replay snapshot write metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReplaySnapshotWrite {
+    pub path: PathBuf,
+    pub event_count: usize,
+    pub forest_count: usize,
+}
+
+/// Error metadata for a failed replay snapshot write.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("failed to write replay snapshot to {}: {}", path.display(), message)]
+pub struct ReplaySnapshotWriteError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+/// Shared status handle for a configured replay snapshot write.
+#[derive(Clone, Debug, Default)]
+pub struct ReplaySnapshotRecorder {
+    status: Arc<Mutex<Option<Result<ReplaySnapshotWrite, ReplaySnapshotWriteError>>>>,
+}
+
+impl ReplaySnapshotRecorder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the last snapshot write status, leaving the handle empty.
+    pub fn take(&self) -> Option<Result<ReplaySnapshotWrite, ReplaySnapshotWriteError>> {
+        self.status.lock().expect("replay snapshot status poisoned").take()
+    }
+
+    pub(crate) fn record_success(&self, write: ReplaySnapshotWrite) {
+        *self.status.lock().expect("replay snapshot status poisoned") = Some(Ok(write));
+    }
+
+    pub(crate) fn record_error(&self, path: PathBuf, err: impl ToString) {
+        *self.status.lock().expect("replay snapshot status poisoned") =
+            Some(Err(ReplaySnapshotWriteError {
+                path,
+                message: err.to_string(),
+            }));
+    }
+}
+
 /// Magic bytes identifying a replay snapshot file, followed by a format version. Bumping the
 /// version invalidates older snapshots, whose serialized shape may differ.
 const SNAPSHOT_MAGIC: [u8; 6] = *b"MDNSNP";
@@ -72,6 +120,8 @@ pub struct ReplaySnapshot {
     pub stack_inputs: StackInputs,
     /// The advice inputs the program started with.
     pub advice_inputs: AdviceInputs,
+    /// The VM execution options used by the recorded run.
+    pub options: ExecutionOptions,
     /// The MAST forests resolved by the host during execution (account code, note scripts, ...),
     /// which the replay host must be able to resolve for the same `call`/`dyncall` targets.
     pub mast_forests: Vec<Arc<MastForest>>,
@@ -113,6 +163,7 @@ impl Serializable for ReplaySnapshot {
         self.program.write_into(target);
         self.stack_inputs.write_into(target);
         self.advice_inputs.write_into(target);
+        write_execution_options(&self.options, target);
         target.write_usize(self.mast_forests.len());
         for forest in &self.mast_forests {
             forest.as_ref().write_into(target);
@@ -138,6 +189,7 @@ impl Deserializable for ReplaySnapshot {
         let program = Program::read_from(source)?;
         let stack_inputs = StackInputs::read_from(source)?;
         let advice_inputs = AdviceInputs::read_from(source)?;
+        let options = read_execution_options(source)?;
         let forest_count = source.read_usize()?;
         let mut mast_forests = Vec::with_capacity(forest_count);
         for _ in 0..forest_count {
@@ -148,10 +200,59 @@ impl Deserializable for ReplaySnapshot {
             program,
             stack_inputs,
             advice_inputs,
+            options,
             mast_forests,
             event_log,
         })
     }
+}
+
+fn write_execution_options<W: ByteWriter>(options: &ExecutionOptions, target: &mut W) {
+    target.write_u32(options.max_cycles());
+    target.write_u32(options.expected_cycles());
+    target.write_usize(options.core_trace_fragment_size());
+    target.write_bool(options.enable_tracing());
+    target.write_bool(options.enable_debugging());
+    target.write_usize(options.max_adv_map_value_size());
+    target.write_usize(options.max_adv_map_elements());
+    target.write_usize(options.max_hash_len_bytes());
+    target.write_usize(options.max_num_continuations());
+    target.write_usize(options.max_stack_depth());
+}
+
+fn read_execution_options<R: ByteReader>(
+    source: &mut R,
+) -> Result<ExecutionOptions, DeserializationError> {
+    let max_cycles = source.read_u32()?;
+    let expected_cycles = source.read_u32()?;
+    let core_trace_fragment_size = source.read_usize()?;
+    let enable_tracing = source.read_bool()?;
+    let enable_debugging = source.read_bool()?;
+    let max_adv_map_value_size = source.read_usize()?;
+    let max_adv_map_elements = source.read_usize()?;
+    let max_hash_len_bytes = source.read_usize()?;
+    let max_num_continuations = source.read_usize()?;
+    let max_stack_depth = source.read_usize()?;
+
+    ExecutionOptions::new(
+        Some(max_cycles),
+        expected_cycles,
+        core_trace_fragment_size,
+        enable_tracing,
+        enable_debugging,
+    )
+    .map_err(|err| DeserializationError::InvalidValue(format!("invalid execution options: {err}")))
+    .and_then(|options| {
+        options
+            .with_max_adv_map_value_size(max_adv_map_value_size)
+            .with_max_adv_map_elements(max_adv_map_elements)
+            .with_max_hash_len_bytes(max_hash_len_bytes)
+            .with_max_num_continuations(max_num_continuations)
+            .with_max_stack_depth(max_stack_depth)
+            .map_err(|err| {
+                DeserializationError::InvalidValue(format!("invalid execution options: {err}"))
+            })
+    })
 }
 
 /// Error reading a [ReplaySnapshot] from a file.
@@ -198,6 +299,14 @@ mod tests {
             program: program.clone(),
             stack_inputs: StackInputs::new(&[Felt::from(42u32), Felt::from(43u32)]).unwrap(),
             advice_inputs: AdviceInputs::default().with_stack([Felt::from(99u32)]),
+            options: ExecutionOptions::new(Some(100_000), 32, 1024, true, true)
+                .unwrap()
+                .with_max_adv_map_value_size(64)
+                .with_max_adv_map_elements(256)
+                .with_max_hash_len_bytes(512)
+                .with_max_num_continuations(128)
+                .with_max_stack_depth(128)
+                .unwrap(),
             mast_forests: vec![forest],
             event_log,
         };
@@ -208,6 +317,7 @@ mod tests {
         assert_eq!(restored.program.hash(), snapshot.program.hash());
         assert_eq!(restored.stack_inputs, snapshot.stack_inputs);
         assert_eq!(restored.advice_inputs, snapshot.advice_inputs);
+        assert_eq!(restored.options, snapshot.options);
         assert_eq!(restored.mast_forests.len(), 1);
         assert_eq!(restored.event_log.len(), 3);
         assert_eq!(restored.event_log[1].len(), 0, "empty event batch must survive");

--- a/crates/engine/src/exec/snapshot.rs
+++ b/crates/engine/src/exec/snapshot.rs
@@ -1,0 +1,236 @@
+//! A self-contained snapshot of a recorded execution, sufficient to replay it in the debugger
+//! without the original host.
+//!
+//! A live execution (e.g. a transaction driven through the DAP executor) resolves two kinds of
+//! host interaction that a bare debugger host cannot reproduce on its own: the advice mutations
+//! returned by event handlers, and the MAST forests resolved for `call`/`dyncall` targets (account
+//! code, note scripts, etc.). A [ReplaySnapshot] captures both, alongside the program and its
+//! inputs, so the same execution can be re-run later by feeding the recorded event log into an
+//! event-replay debugger host (see [`Executor::into_debug_with_replay`](crate::exec::Executor) and
+//! `State::new_for_transaction`).
+
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use miden_core::{
+    mast::MastForest,
+    program::{Program, StackInputs},
+    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
+use miden_processor::advice::{AdviceInputs, AdviceMutation};
+
+use super::advice::{read_event_log, write_event_log};
+
+/// A shared, cloneable log of the MAST forests a host resolved during execution.
+///
+/// The debugger's event-replay host serves recorded advice mutations for `on_event`, but it still
+/// has to resolve the code for `call`/`dyncall` targets itself. Recording the forests the live
+/// host returned — deduplicated, since the same forest is resolved for many nodes — lets the
+/// replay host load exactly that set and reach the same targets.
+#[derive(Clone, Default)]
+pub struct MastForestRecorder {
+    forests: Arc<Mutex<Vec<Arc<MastForest>>>>,
+}
+
+impl MastForestRecorder {
+    /// Create a new, empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a copy of the recorded forests.
+    pub fn snapshot(&self) -> Vec<Arc<MastForest>> {
+        self.forests.lock().expect("mast forest log poisoned").clone()
+    }
+
+    /// Record a forest resolved by the host, ignoring forests already recorded this run.
+    pub(crate) fn record(&self, forest: Arc<MastForest>) {
+        let mut guard = self.forests.lock().expect("mast forest log poisoned");
+        if !guard.iter().any(|existing| Arc::ptr_eq(existing, &forest)) {
+            guard.push(forest);
+        }
+    }
+
+    /// Discard everything recorded so far, e.g. when execution restarts from the beginning.
+    pub(crate) fn clear(&self) {
+        self.forests.lock().expect("mast forest log poisoned").clear();
+    }
+}
+
+/// Magic bytes identifying a replay snapshot file, followed by a format version. Bumping the
+/// version invalidates older snapshots, whose serialized shape may differ.
+const SNAPSHOT_MAGIC: [u8; 6] = *b"MDNSNP";
+const SNAPSHOT_VERSION: u8 = 1;
+
+/// Everything needed to replay a recorded execution in the debugger.
+pub struct ReplaySnapshot {
+    /// The program that was executed (for a transaction, the transaction kernel).
+    pub program: Program,
+    /// The operand stack inputs the program started with.
+    pub stack_inputs: StackInputs,
+    /// The advice inputs the program started with.
+    pub advice_inputs: AdviceInputs,
+    /// The MAST forests resolved by the host during execution (account code, note scripts, ...),
+    /// which the replay host must be able to resolve for the same `call`/`dyncall` targets.
+    pub mast_forests: Vec<Arc<MastForest>>,
+    /// The advice mutations produced by event handlers, one entry per `on_event` invocation, in
+    /// execution order — the event replay queue.
+    pub event_log: Vec<Vec<AdviceMutation>>,
+}
+
+impl ReplaySnapshot {
+    /// Serialize the snapshot to `path`.
+    pub fn write_to_file(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::write(path, self.to_bytes())
+    }
+
+    /// Read and deserialize a snapshot from `path`.
+    pub fn read_from_file(path: impl AsRef<Path>) -> Result<Self, ReplaySnapshotError> {
+        let bytes = std::fs::read(path).map_err(ReplaySnapshotError::Io)?;
+        Self::read_from_bytes(&bytes).map_err(ReplaySnapshotError::Deserialization)
+    }
+
+    /// Serialize the snapshot to a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        self.write_into(&mut bytes);
+        bytes
+    }
+
+    /// Deserialize a snapshot from bytes.
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        let mut reader = miden_core::serde::SliceReader::new(bytes);
+        Self::read_from(&mut reader)
+    }
+}
+
+impl Serializable for ReplaySnapshot {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_bytes(&SNAPSHOT_MAGIC);
+        target.write_u8(SNAPSHOT_VERSION);
+        self.program.write_into(target);
+        self.stack_inputs.write_into(target);
+        self.advice_inputs.write_into(target);
+        target.write_usize(self.mast_forests.len());
+        for forest in &self.mast_forests {
+            forest.as_ref().write_into(target);
+        }
+        write_event_log(&self.event_log, target);
+    }
+}
+
+impl Deserializable for ReplaySnapshot {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let magic: [u8; 6] = source.read_array()?;
+        if magic != SNAPSHOT_MAGIC {
+            return Err(DeserializationError::InvalidValue(
+                "not a Miden debugger replay snapshot (bad magic)".to_string(),
+            ));
+        }
+        let version = source.read_u8()?;
+        if version != SNAPSHOT_VERSION {
+            return Err(DeserializationError::InvalidValue(format!(
+                "unsupported replay snapshot version {version} (expected {SNAPSHOT_VERSION})"
+            )));
+        }
+        let program = Program::read_from(source)?;
+        let stack_inputs = StackInputs::read_from(source)?;
+        let advice_inputs = AdviceInputs::read_from(source)?;
+        let forest_count = source.read_usize()?;
+        let mut mast_forests = Vec::with_capacity(forest_count);
+        for _ in 0..forest_count {
+            mast_forests.push(Arc::new(MastForest::read_from(source)?));
+        }
+        let event_log = read_event_log(source)?;
+        Ok(Self {
+            program,
+            stack_inputs,
+            advice_inputs,
+            mast_forests,
+            event_log,
+        })
+    }
+}
+
+/// Error reading a [ReplaySnapshot] from a file.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplaySnapshotError {
+    #[error("failed to read replay snapshot file: {0}")]
+    Io(std::io::Error),
+    #[error("failed to deserialize replay snapshot: {0}")]
+    Deserialization(DeserializationError),
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_assembly::{Assembler, DefaultSourceManager};
+    use miden_core::{Felt, Word, crypto::merkle::InnerNodeInfo};
+
+    use super::*;
+
+    fn word(values: [u32; 4]) -> Word {
+        Word::from(values.map(Felt::from))
+    }
+
+    /// A snapshot round-trips through bytes: program, inputs, forests, and the event log — across
+    /// the AdviceMutation variant shapes that carry simple payloads — survive intact.
+    #[test]
+    fn replay_snapshot_round_trips() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let program = Assembler::new(source_manager)
+            .assemble_program("begin push.1 push.2 add drop end")
+            .expect("failed to assemble test program");
+        let forest = program.mast_forest().clone();
+
+        let event_log = vec![
+            vec![AdviceMutation::extend_stack([Felt::from(7u32), Felt::from(8u32)])],
+            vec![],
+            vec![AdviceMutation::extend_merkle_store([InnerNodeInfo {
+                value: word([1, 2, 3, 4]),
+                left: word([5, 6, 7, 8]),
+                right: word([9, 10, 11, 12]),
+            }])],
+        ];
+
+        let snapshot = ReplaySnapshot {
+            program: program.clone(),
+            stack_inputs: StackInputs::new(&[Felt::from(42u32), Felt::from(43u32)]).unwrap(),
+            advice_inputs: AdviceInputs::default().with_stack([Felt::from(99u32)]),
+            mast_forests: vec![forest],
+            event_log,
+        };
+
+        let restored = ReplaySnapshot::read_from_bytes(&snapshot.to_bytes())
+            .expect("snapshot failed to deserialize");
+
+        assert_eq!(restored.program.hash(), snapshot.program.hash());
+        assert_eq!(restored.stack_inputs, snapshot.stack_inputs);
+        assert_eq!(restored.advice_inputs, snapshot.advice_inputs);
+        assert_eq!(restored.mast_forests.len(), 1);
+        assert_eq!(restored.event_log.len(), 3);
+        assert_eq!(restored.event_log[1].len(), 0, "empty event batch must survive");
+        match restored.event_log[0].as_slice() {
+            [AdviceMutation::ExtendStack { values }] => {
+                assert_eq!(values.as_slice(), &[Felt::from(7u32), Felt::from(8u32)]);
+            }
+            _ => panic!("unexpected first event batch"),
+        }
+        match restored.event_log[2].as_slice() {
+            [AdviceMutation::ExtendMerkleStore { infos }] => {
+                assert_eq!(infos.len(), 1);
+                assert_eq!(infos[0].value, word([1, 2, 3, 4]));
+                assert_eq!(infos[0].right, word([9, 10, 11, 12]));
+            }
+            _ => panic!("unexpected merkle-store event batch"),
+        }
+    }
+
+    /// A file that does not start with the snapshot magic is rejected.
+    #[test]
+    fn replay_snapshot_rejects_bad_magic() {
+        let err = ReplaySnapshot::read_from_bytes(b"not a snapshot at all really");
+        assert!(err.is_err(), "expected deserialization to fail on bad magic");
+    }
+}

--- a/docs/external/src/record-replay-notes.md
+++ b/docs/external/src/record-replay-notes.md
@@ -34,8 +34,8 @@ WALLET=$(HOME="$STORE" miden-client account -l | grep -oE '0x[0-9a-f]+' | head -
 echo "Fund THIS exact ID at the faucet: $WALLET"
 ```
 
-Go to <https://faucet.testnet.miden.io/>, paste `$WALLET`, and click **Send Public
-Note**. The faucet sends a P2ID note to your wallet.
+Go to the [Miden testnet faucet](https://faucet.testnet.miden.io/), paste `$WALLET`, and
+click **Send Public Note**. The faucet sends a P2ID note to your wallet.
 
 > Keep using the same absolute `HOME="$STORE"` on every command — it pins the client's
 > store to one location. And fund the *exact* ID that `account -l` prints; a P2ID note

--- a/docs/external/src/record-replay-notes.md
+++ b/docs/external/src/record-replay-notes.md
@@ -1,0 +1,94 @@
+---
+title: Recording and replaying transactions
+sidebar_position: 7
+---
+
+# Recording and replaying transactions
+
+A DAP session driven by `miden-client` can **record** a transaction — the program,
+its inputs, the resolved code, and every advice mutation produced by the transaction
+host's event handlers — into a self-contained *replay snapshot*. The snapshot can then
+be **replayed** offline in the `miden-debug` TUI, with no node, client, or account
+state, so you can step through the exact same execution as many times as you like.
+
+This is the simplest way to debug a real note-consumption transaction (e.g. a P2ID
+note) end to end.
+
+Both tools below are the locally built binaries: `miden-client` from the
+[miden-client](https://github.com/0xMiden/miden-client) repo (built with the `dap`
+feature) and `miden-debug` from this repo.
+
+## Record a note-consumption transaction
+
+The example uses the public testnet, so no local node is needed.
+
+### 1. Create and fund a wallet
+
+```bash
+STORE="$HOME/miden-p2id-testnet"
+rm -rf "$STORE" && mkdir -p "$STORE"
+
+HOME="$STORE" miden-client init --network testnet
+HOME="$STORE" miden-client new-wallet
+WALLET=$(HOME="$STORE" miden-client account -l | grep -oE '0x[0-9a-f]+' | head -1)
+echo "Fund THIS exact ID at the faucet: $WALLET"
+```
+
+Go to <https://faucet.testnet.miden.io/>, paste `$WALLET`, and click **Send Public
+Note**. The faucet sends a P2ID note to your wallet.
+
+> Keep using the same absolute `HOME="$STORE"` on every command — it pins the client's
+> store to one location. And fund the *exact* ID that `account -l` prints; a P2ID note
+> asserts that the consuming account equals the note's target.
+
+### 2. Find the note
+
+```bash
+HOME="$STORE" miden-client sync                              # wait ~20s after funding
+HOME="$STORE" miden-client notes -l consumable -a "$WALLET"  # copy the Note ID it lists
+```
+
+### 3. Debug and record the consumption
+
+The `consume-notes` command runs the transaction under a DAP server instead of proving
+and submitting it, and `--record` writes the replay snapshot when the session ends.
+
+**Terminal 1** — start the debug adapter (replace `<NOTE_ID>` with the ID from step 2):
+
+```bash
+HOME="$STORE" miden-client consume-notes -a "$WALLET" <NOTE_ID> \
+  --start-debug-adapter 127.0.0.1:4711 \
+  --record "$STORE/p2id.mdsnap"
+```
+
+**Terminal 2** — attach the debugger and step through the transaction (kernel → note
+script → the wallet's `receive_asset`); press `c` to run to the end, `q` to quit:
+
+```bash
+miden-debug --dap-connect 127.0.0.1:4711
+```
+
+When the session ends, Terminal 1 reports the snapshot:
+
+```text
+Wrote replay snapshot (542 event(s), 5 forest(s)) to .../p2id.mdsnap
+Recorded 542 advice mutation set(s) from event handlers during the debug session.
+Wrote replay snapshot to .../p2id.mdsnap; replay it with `miden-debug --replay .../p2id.mdsnap`.
+```
+
+## Replay offline
+
+```bash
+miden-debug --replay "$STORE/p2id.mdsnap"
+```
+
+The recorded events are fed back through the debugger's event-replay host, so you step
+through the identical execution — no network or wallet required. The snapshot carries no
+source files, so the debugger shows disassembly.
+
+## Replaying a failed transaction
+
+A snapshot is written even when the debugged transaction **fails** mid-execution (for
+example, a note-script assertion). This captures the run up to the failure point, so you
+can replay a failing consume offline and step right up to where it went wrong — often the
+most useful case to debug.

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,17 @@ pub struct DebuggerConfig {
         )
     )]
     pub source_path_prefixes: Vec<PathBuf>,
+    /// Replay a recorded execution snapshot in the TUI debugger.
+    ///
+    /// FILE is a snapshot written during a recorded debug session (e.g.
+    /// `miden-client exec --start-debug-adapter <ADDR> --record <FILE>`). The recorded program,
+    /// inputs, resolved code, and event log are replayed so the same execution can be stepped
+    /// through offline, without the original host.
+    #[cfg_attr(
+        feature = "tui",
+        arg(long, value_name = "FILE", help_heading = "Execution")
+    )]
+    pub replay: Option<PathBuf>,
     /// Specify one or more search paths for link libraries requested via `-l`
     #[cfg_attr(
         any(feature = "tui", feature = "flamegraph"),

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -211,6 +211,7 @@ impl FlamegraphArgs {
             link_libraries: self.link_libraries,
             repl: false,
             commands: None,
+            replay: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ pub use self::repl::{
 };
 #[cfg(feature = "tui")]
 pub use self::ui::{
-    DebugMode, State, run, run_with_log_level, run_with_state, run_with_state_and_log_level,
+    DebugMode, State, run, run_replay_and_log_level, run_with_log_level, run_with_state,
+    run_with_state_and_log_level,
 };
 pub use self::{
     config::{ColorChoice, DebuggerConfig},

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use miden_debug::flamegraph::FlamegraphArgs;
 #[cfg(feature = "repl")]
 use miden_debug::run_repl_with_log_level as run_repl;
 #[cfg(feature = "tui")]
+use miden_debug::run_replay_and_log_level;
+#[cfg(feature = "tui")]
 use miden_debug::run_with_log_level as run;
 #[cfg(feature = "dap")]
 use miden_debug::{State, run_with_state_and_log_level as run_with_state};
@@ -87,6 +89,11 @@ fn run_debugger(
             .wrap_err("could not read current working directory")?;
 
         config.working_dir = Some(cwd);
+    }
+
+    #[cfg(feature = "tui")]
+    if let Some(snapshot_path) = config.replay.clone() {
+        return run_replay_and_log_level(&snapshot_path, _logger, _log_level);
     }
 
     #[cfg(feature = "dap")]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -48,6 +48,39 @@ pub fn run_with_state_and_log_level(
     rt.block_on(async move { start_ui_with_state(state, logger, max_level).await })
 }
 
+/// Replay a recorded execution snapshot in the TUI debugger.
+///
+/// Reads a [`ReplaySnapshot`](crate::exec::ReplaySnapshot) written during a recorded DAP session
+/// (e.g. `miden-client exec --start-debug-adapter ... --record <FILE>`) and re-runs the same
+/// program with its captured inputs, forests, and event log fed back through the event-replay
+/// host — so the transaction can be stepped through offline, without the original host.
+pub fn run_replay_and_log_level(
+    snapshot_path: &std::path::Path,
+    logger: Box<dyn log::Log>,
+    max_level: LevelFilter,
+) -> Result<(), Report> {
+    use std::sync::Arc;
+
+    use miden_assembly::DefaultSourceManager;
+
+    use crate::exec::ReplaySnapshot;
+
+    let snapshot = ReplaySnapshot::read_from_file(snapshot_path)
+        .map_err(|err| Report::msg(format!("{err}")))?;
+    // The snapshot does not carry source files; the debugger falls back to disassembly, exactly
+    // as it does for a raw program with no debug info.
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let state = State::new_for_transaction(
+        Arc::new(snapshot.program),
+        snapshot.stack_inputs,
+        snapshot.advice_inputs,
+        source_manager,
+        snapshot.mast_forests,
+        snapshot.event_log,
+    )?;
+    run_with_state_and_log_level(state, logger, max_level)
+}
+
 #[allow(dead_code)]
 pub async fn start_ui(
     config: Box<DebuggerConfig>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -74,6 +74,7 @@ pub fn run_replay_and_log_level(
         Arc::new(snapshot.program),
         snapshot.stack_inputs,
         snapshot.advice_inputs,
+        snapshot.options,
         source_manager,
         snapshot.mast_forests,
         snapshot.event_log,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -36,27 +36,10 @@ pub enum DebugMode {
     Remote,
 }
 
-fn clone_advice_mutation(mutation: &AdviceMutation) -> AdviceMutation {
-    match mutation {
-        AdviceMutation::ExtendStack { values } => AdviceMutation::ExtendStack {
-            values: values.clone(),
-        },
-        AdviceMutation::ExtendMap { other } => AdviceMutation::ExtendMap {
-            other: other.clone(),
-        },
-        AdviceMutation::ExtendMerkleStore { infos } => AdviceMutation::ExtendMerkleStore {
-            infos: infos.clone(),
-        },
-        AdviceMutation::ExtendPrecompileRequests { data } => {
-            AdviceMutation::ExtendPrecompileRequests { data: data.clone() }
-        }
-    }
-}
-
 fn clone_event_replay_queue(event_replay: &[Vec<AdviceMutation>]) -> VecDeque<Vec<AdviceMutation>> {
     event_replay
         .iter()
-        .map(|batch| batch.iter().map(clone_advice_mutation).collect())
+        .map(|batch| crate::exec::clone_advice_mutations(batch))
         .collect()
 }
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -22,7 +22,7 @@ use miden_processor::{
 use crate::{
     config::DebuggerConfig,
     debug::{Breakpoint, BreakpointType, ReadMemoryExpr, ResolvedLocation, resolve_variable_value},
-    exec::{DebugExecutor, Executor},
+    exec::{DebugExecutor, ExecutionConfig, Executor},
 };
 
 /// Whether the debugger is debugging a plain program or a transaction.
@@ -271,15 +271,17 @@ impl State {
         program: Arc<Program>,
         stack_inputs: StackInputs,
         advice_inputs: AdviceInputs,
+        options: miden_processor::ExecutionOptions,
         source_manager: Arc<dyn SourceManager>,
         mast_forests: Vec<Arc<MastForest>>,
         event_replay: Vec<Vec<AdviceMutation>>,
     ) -> Result<Self, Report> {
-        let args = stack_inputs.iter().copied().rev().collect::<Vec<_>>();
-
-        // Create debug executor with event replay
-        let mut executor = Executor::new(args);
-        executor.with_advice_inputs(advice_inputs);
+        // Create debug executor with the exact recorded inputs and options.
+        let executor = Executor::from_config(ExecutionConfig {
+            inputs: stack_inputs,
+            advice_inputs,
+            options,
+        });
         let debug_executor = executor.into_debug_with_replay(
             &program,
             source_manager.clone(),


### PR DESCRIPTION
Debugging a transaction with event replay requires the AdviceMutations produced by the original execution's event handlers, but nothing on the capture side recorded them: DapHostWrapper and DebuggerHost both discarded handler results after applying them.

Introduce EventMutationRecorder, a shared, cloneable log that records one entry per on_event invocation in execution order - including empty mutation sets, since replay pops exactly one entry per event and the log must stay aligned with the event stream. Recording hooks:

- DapExecutor::record_event_mutations() returns a handle recorded into by the DAP host wrapper around the client-provided host (e.g. miden-tx's TransactionExecutorHost); the log resets whenever a DAP session restarts execution, so it always describes the final run.
- Executor::record_event_mutations() does the same for the engine's own DebuggerHost; nothing is recorded while a replay queue is being consumed.