### PR TITLE
feat(prof): collect and print op histogram

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "socket2",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1779,7 @@ version = "0.8.0"
 dependencies = [
  "clap",
  "glob",
+ "inventory",
  "log",
  "miden-assembly",
  "miden-assembly-syntax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2024"
 clap = { version = "4.5", default-features = false, features = ["derive", "std", "env", "help", "suggestions", "error-context"]}
 dap = { package = "miden-debug-dap", version = "0.8.0", path = "crates/dap", features = ["client"] }
 log = "0.4"
+inventory = "0.3"
 miden-debug-engine = { version = "0.8.0", path = "crates/engine", default-features = false }
 miden-assembly = { version = "0.25" }
 miden-assembly-syntax = { version = "0.25" }
@@ -36,6 +37,14 @@ serde = { version = "1.0", default-features = false, features = [
 ] }
 serde_json = "1"
 thiserror = "2.0"
+
+[profile.dev]
+# Needed for 'inventory' to work
+codegen-units = 1
+
+[profile.release]
+# Needed for 'inventory' to work
+codegen-units = 1
 
 [package]
 name = "miden-debug"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -50,3 +50,6 @@ smallvec = { version = "1.14", default-features = false, features = [
 ] }
 thiserror.workspace = true
 toml = { version = "1.1.2", features = ["preserve_order"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -26,6 +26,7 @@ proptest = ["dep:proptest"]
 clap.workspace = true
 dap = { workspace = true, optional = true, features = ["client"] }
 glob = { version = "0.3.1", optional = true }
+inventory.workspace = true
 log.workspace = true
 miden-assembly.workspace = true
 miden-assembly-syntax.workspace = true

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -30,6 +30,7 @@ use crate::{
     HybridPackageRegistry,
     debug::{CallStack, DebugVarTracker, NativePtr},
     felt::FromMidenRepr,
+    profiling::{Profiler, ProfilerConfig},
 };
 
 /// Maximum number of bytes for a single `println` output.
@@ -53,6 +54,7 @@ pub struct Executor {
     event_handlers: Vec<(EventName, Arc<dyn EventHandler>)>,
     registry: HybridPackageRegistry,
     record_event_mutations: bool,
+    profiler_config: ProfilerConfig,
 }
 
 impl Executor {
@@ -83,6 +85,7 @@ impl Executor {
             event_handlers: Default::default(),
             registry: HybridPackageRegistry::empty(),
             record_event_mutations: false,
+            profiler_config: Default::default(),
         }
     }
 
@@ -127,6 +130,12 @@ impl Executor {
     ) -> Result<&mut Self, ExecutionError> {
         self.event_handlers.push((event, handler));
         Ok(self)
+    }
+
+    /// Set the profiler configuration for this executor.
+    pub fn with_profiler_config(&mut self, profiler_config: ProfilerConfig) -> &mut Self {
+        self.profiler_config = profiler_config;
+        self
     }
 
     /// Convert this [Executor] into a [DebugExecutor], which captures much more information
@@ -187,6 +196,7 @@ impl Executor {
             recent: VecDeque::with_capacity(5),
             cycle: 0,
             stopped: false,
+            profiler: Profiler::from_config(self.profiler_config),
         }
     }
 
@@ -252,6 +262,7 @@ impl Executor {
             recent: VecDeque::with_capacity(5),
             cycle: 0,
             stopped: false,
+            profiler: Profiler::from_config(self.profiler_config),
         }
     }
 

--- a/crates/engine/src/exec/state.rs
+++ b/crates/engine/src/exec/state.rs
@@ -22,6 +22,7 @@ use crate::{
         CallFrame, CallStack, ControlFlowOp, DebugVarTracker, StepInfo,
         snapshot_transient_debug_values,
     },
+    profiling::Profiler,
 };
 
 /// Resolve a future that is expected to complete immediately (synchronous host methods).
@@ -84,6 +85,8 @@ pub struct DebugExecutor {
     pub cycle: usize,
     /// Whether or not execution has terminated
     pub stopped: bool,
+    /// The profiler used by this executor
+    pub profiler: Profiler,
 }
 
 impl super::query::DebugQuery for DebugExecutor {
@@ -292,6 +295,7 @@ impl DebugExecutor {
                         self.recent.pop_front();
                     }
                     self.recent.push_back(op);
+                    self.profiler.on_operation_execution_cycle(op);
                 }
 
                 // Update call stack
@@ -324,6 +328,9 @@ impl DebugExecutor {
                 let len = self.current_stack.len().min(16);
                 self.stack_outputs =
                     StackOutputs::new(&self.current_stack[..len]).expect("invalid stack outputs");
+
+                // Write profiling reports in case its enabled
+                self.profiler.write_reports();
                 Ok(None)
             }
             Err(err) => {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2,6 +2,7 @@ pub mod debug;
 pub mod exec;
 pub mod felt;
 mod linker;
+pub mod profiling;
 mod registry;
 #[cfg(test)]
 mod test_utils;

--- a/crates/engine/src/profiling/config.rs
+++ b/crates/engine/src/profiling/config.rs
@@ -1,0 +1,55 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use crate::profiling::instrument::{Instrument, OpHistogram};
+
+/// Profiler options parsed from the command line.
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "tui", derive(clap::Args))]
+pub struct ProfilerCliArgs {
+    /// Generate an op histogram weighted by cycles and write it to the given path.
+    #[cfg_attr(
+        feature = "tui",
+        arg(long = "profile-op-histogram-out", value_name = "FILE")
+    )]
+    pub op_histogram_out: Option<PathBuf>,
+}
+
+#[derive(Default)]
+pub struct ProfilerConfig {
+    /// The active instrumentations.
+    pub instruments: Vec<Box<dyn Instrument>>,
+    /// Optional output file per instrument.
+    pub output_paths: HashMap<&'static str, PathBuf>,
+}
+
+impl ProfilerConfig {
+    /// Associates an output file `path` with `instrument`, keyed by its name.
+    pub fn register_output_path(&mut self, instrument: &dyn Instrument, path: PathBuf) {
+        self.output_paths.insert(instrument.name(), path);
+    }
+}
+
+impl From<ProfilerCliArgs> for ProfilerConfig {
+    fn from(args: ProfilerCliArgs) -> Self {
+        let mut config = ProfilerConfig::default();
+
+        if let Some(path) = args.op_histogram_out {
+            let op_histogram: Box<OpHistogram> = Box::default();
+            config.register_output_path(op_histogram.as_ref(), path);
+            config.instruments.push(op_histogram);
+        }
+
+        config
+    }
+}
+
+impl std::fmt::Debug for ProfilerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let instrument_names: Vec<&'static str> =
+            self.instruments.iter().map(|i| i.name()).collect();
+        f.debug_struct("ProfilerConfig")
+            .field("instruments", &instrument_names)
+            .field("output_paths", &self.output_paths)
+            .finish()
+    }
+}

--- a/crates/engine/src/profiling/config.rs
+++ b/crates/engine/src/profiling/config.rs
@@ -37,7 +37,7 @@ pub struct ProfilerConfig {
 impl TryFrom<ProfilerCliArgs> for ProfilerConfig {
     type Error = Report;
 
-    fn try_from(args: ProfilerCliArgs) -> Result<Self, Self::Error> {
+    fn try_from(mut args: ProfilerCliArgs) -> Result<Self, Self::Error> {
         let mut config = ProfilerConfig::default();
 
         if let Some(ref path) = args.reports_dir
@@ -64,9 +64,10 @@ impl TryFrom<ProfilerCliArgs> for ProfilerConfig {
 
         config.reports_dir = args.reports_dir;
 
+        args.instruments.sort();
+        args.instruments.dedup();
         for name in &args.instruments {
-            let instrument = instrument_from_name(name)
-                .ok_or_else(|| Report::msg(format!("unknown profiling instrument '{name}'")))?;
+            let instrument = instrument_from_name(name, &config).map_err(Report::msg)?;
             config.instruments.push(instrument);
         }
 

--- a/crates/engine/src/profiling/config.rs
+++ b/crates/engine/src/profiling/config.rs
@@ -1,45 +1,76 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
-use crate::profiling::instrument::{Instrument, OpHistogram};
+use miden_assembly_syntax::diagnostics::Report;
+
+use crate::profiling::{instrument::Instrument, instrument_from_name};
 
 /// Profiler options parsed from the command line.
 #[derive(Default, Clone, Debug)]
 #[cfg_attr(feature = "tui", derive(clap::Args))]
 pub struct ProfilerCliArgs {
-    /// Generate an op histogram weighted by cycles and write it to the given path.
+    /// Enables profiling and sets the output dir for reports. Profiling
+    /// instruments need to be enabled separately.
     #[cfg_attr(
         feature = "tui",
-        arg(long = "profile-op-histogram-out", value_name = "FILE")
+        arg(long = "profiling-reports-dir", value_name = "DIRECTORY")
     )]
-    pub op_histogram_out: Option<PathBuf>,
+    pub reports_dir: Option<PathBuf>,
+    #[cfg_attr(
+        feature = "tui",
+        arg(
+            long = "profiling-instruments",
+            value_name = "VALUE",
+            value_delimiter = ','
+        )
+    )]
+    pub instruments: Vec<String>,
 }
 
 #[derive(Default)]
 pub struct ProfilerConfig {
     /// The active instrumentations.
     pub instruments: Vec<Box<dyn Instrument>>,
-    /// Optional output file per instrument.
-    pub output_paths: HashMap<&'static str, PathBuf>,
+    /// The directory where profiling reports are written.
+    pub reports_dir: Option<PathBuf>,
 }
 
-impl ProfilerConfig {
-    /// Associates an output file `path` with `instrument`, keyed by its name.
-    pub fn register_output_path(&mut self, instrument: &dyn Instrument, path: PathBuf) {
-        self.output_paths.insert(instrument.name(), path);
-    }
-}
+impl TryFrom<ProfilerCliArgs> for ProfilerConfig {
+    type Error = Report;
 
-impl From<ProfilerCliArgs> for ProfilerConfig {
-    fn from(args: ProfilerCliArgs) -> Self {
+    fn try_from(args: ProfilerCliArgs) -> Result<Self, Self::Error> {
         let mut config = ProfilerConfig::default();
 
-        if let Some(path) = args.op_histogram_out {
-            let op_histogram: Box<OpHistogram> = Box::default();
-            config.register_output_path(op_histogram.as_ref(), path);
-            config.instruments.push(op_histogram);
+        if let Some(ref path) = args.reports_dir
+            && path.exists()
+            && !path.is_dir()
+        {
+            return Err(Report::msg(format!(
+                "invalid profiling reports directory '{}': not a directory",
+                path.display()
+            )));
         }
 
-        config
+        if args.reports_dir.is_some() && args.instruments.is_empty() {
+            return Err(Report::msg(
+                "profiling requires at least one instrument set with --profiling-instruments",
+            ));
+        }
+
+        if args.reports_dir.is_none() && !args.instruments.is_empty() {
+            return Err(Report::msg(
+                "profiling instruments require --profiling-reports-dir to be set",
+            ));
+        }
+
+        config.reports_dir = args.reports_dir;
+
+        for name in &args.instruments {
+            let instrument = instrument_from_name(name)
+                .ok_or_else(|| Report::msg(format!("unknown profiling instrument '{name}'")))?;
+            config.instruments.push(instrument);
+        }
+
+        Ok(config)
     }
 }
 
@@ -49,7 +80,7 @@ impl std::fmt::Debug for ProfilerConfig {
             self.instruments.iter().map(|i| i.name()).collect();
         f.debug_struct("ProfilerConfig")
             .field("instruments", &instrument_names)
-            .field("output_paths", &self.output_paths)
+            .field("reports_dir", &self.reports_dir)
             .finish()
     }
 }

--- a/crates/engine/src/profiling/instrument/mod.rs
+++ b/crates/engine/src/profiling/instrument/mod.rs
@@ -5,24 +5,85 @@
 
 use miden_core::operations::Operation;
 
-pub mod op_histogram;
+mod op_histogram;
 
 pub use op_histogram::OpHistogram;
 
-pub const INSTRUMENT_NAME_OP_HISTOGRAM: &str = "op-histogram";
-
 /// The functionality required for an instrument to be plugged in to `Profiler`.
 pub trait Instrument {
-    /// The name used to uniquely identify this instrumentation.
+    /// The human readable name of this instrument used in CLI arguments and user output
+    ///
+    /// This should be the same name as the corresponding `InstrumentRegistration::NAME` constant
     fn name(&self) -> &'static str;
     /// To be called each vm cycle an `Operation` is executed.
     fn on_operation_execution_cycle(&mut self, op: Operation);
+    /// Write this instrumentation's collected output as a report to `writer`
     fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()>;
 }
 
-pub fn instrument_from_name(name: &str) -> Option<Box<dyn Instrument>> {
-    match name {
-        INSTRUMENT_NAME_OP_HISTOGRAM => Some(Box::new(OpHistogram::default())),
-        _ => None,
+/// Represents the information needed to construct an [Instrument] dynamically
+pub trait InstrumentRegistration: Sized + Instrument + 'static {
+    /// The human readable name of this instrument used in CLI arguments and user output
+    const NAME: &'static str;
+
+    /// Create an instance of this instrument with the provided configuration
+    fn build(config: &super::ProfilerConfig) -> Result<Self, InstrumentError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InstrumentError {
+    /// The given instrument name is not registered to any known instrument
+    #[error("unknown profiling instrument '{0}'")]
+    Undefined(String),
+    /// We failed to construct the named instrument
+    #[error("failed to construct instrument '{name}': {reason}")]
+    Build { name: String, reason: String },
+}
+
+/// Get an instance of instrument `name`, if one has been registered by that name.
+///
+/// Returns `Err` if no such instrument is registered, or the instrument constructor returned an
+/// error
+pub fn instrument_from_name(
+    name: &str,
+    config: &super::ProfilerConfig,
+) -> Result<Box<dyn Instrument>, InstrumentError> {
+    for instrument in inventory::iter::<InstrumentRegistrationInfo>() {
+        if instrument.name == name {
+            return (instrument.builder)(config);
+        }
     }
+    Err(InstrumentError::Undefined(name.to_string()))
+}
+
+#[doc(hidden)]
+pub struct InstrumentRegistrationInfo {
+    name: &'static str,
+    builder: fn(&super::ProfilerConfig) -> Result<Box<dyn Instrument>, InstrumentError>,
+}
+
+impl InstrumentRegistrationInfo {
+    pub const fn new<T: InstrumentRegistration>() -> Self {
+        let name = <T as InstrumentRegistration>::NAME;
+        Self {
+            name,
+            builder: build_instrument::<T>,
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! register_instrument {
+    ($t:ty) => {
+        inventory::submit!($crate::profiling::instrument::InstrumentRegistrationInfo::new::<$t>());
+    };
+}
+
+inventory::collect!(InstrumentRegistrationInfo);
+
+#[inline]
+fn build_instrument<T: InstrumentRegistration>(
+    config: &super::ProfilerConfig,
+) -> Result<Box<dyn Instrument>, InstrumentError> {
+    <T as InstrumentRegistration>::build(config).map(|inst| Box::new(inst) as Box<dyn Instrument>)
 }

--- a/crates/engine/src/profiling/instrument/mod.rs
+++ b/crates/engine/src/profiling/instrument/mod.rs
@@ -1,0 +1,19 @@
+//! Every distinct kind of profiling data collection is an [`Instrument`] implementation that
+//! lives in a submodule.
+//!
+//! Each instrument is uniquely identified by its [`Instrument::name`].
+
+use miden_core::operations::Operation;
+
+pub mod op_histogram;
+
+pub use op_histogram::OpHistogram;
+
+/// The functionality required for an instrument to be plugged in to `Profiler`.
+pub trait Instrument {
+    /// The name used to uniquely identify this instrumentation.
+    fn name(&self) -> &'static str;
+    /// To be called each vm cycle an `Operation` is executed.
+    fn on_operation_execution_cycle(&mut self, op: Operation);
+    fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()>;
+}

--- a/crates/engine/src/profiling/instrument/mod.rs
+++ b/crates/engine/src/profiling/instrument/mod.rs
@@ -9,6 +9,8 @@ pub mod op_histogram;
 
 pub use op_histogram::OpHistogram;
 
+pub const INSTRUMENT_NAME_OP_HISTOGRAM: &str = "op-histogram";
+
 /// The functionality required for an instrument to be plugged in to `Profiler`.
 pub trait Instrument {
     /// The name used to uniquely identify this instrumentation.
@@ -16,4 +18,11 @@ pub trait Instrument {
     /// To be called each vm cycle an `Operation` is executed.
     fn on_operation_execution_cycle(&mut self, op: Operation);
     fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()>;
+}
+
+pub fn instrument_from_name(name: &str) -> Option<Box<dyn Instrument>> {
+    match name {
+        INSTRUMENT_NAME_OP_HISTOGRAM => Some(Box::new(OpHistogram::default())),
+        _ => None,
+    }
 }

--- a/crates/engine/src/profiling/instrument/op_histogram.rs
+++ b/crates/engine/src/profiling/instrument/op_histogram.rs
@@ -1,6 +1,7 @@
 use miden_core::{Felt, operations::Operation};
 
-use super::{INSTRUMENT_NAME_OP_HISTOGRAM, Instrument};
+use super::{Instrument, InstrumentRegistration};
+use crate::register_instrument;
 
 /// An [`Instrument`] to create operation histograms.
 ///
@@ -21,9 +22,19 @@ impl Default for OpHistogram {
     }
 }
 
+impl InstrumentRegistration for OpHistogram {
+    const NAME: &'static str = "op-histogram";
+
+    fn build(_config: &crate::profiling::ProfilerConfig) -> Result<Self, super::InstrumentError> {
+        Ok(Self::default())
+    }
+}
+
+register_instrument!(OpHistogram);
+
 impl Instrument for OpHistogram {
     fn name(&self) -> &'static str {
-        INSTRUMENT_NAME_OP_HISTOGRAM
+        Self::NAME
     }
 
     fn on_operation_execution_cycle(&mut self, op: Operation) {
@@ -225,7 +236,6 @@ mod tests {
     #[test]
     fn op_histogram_reports_recorded_ops() {
         let mut hist = super::OpHistogram::default();
-        assert_eq!(hist.name(), "op-histogram");
 
         // 3 cycles
         hist.on_operation_execution_cycle(Operation::Add);

--- a/crates/engine/src/profiling/instrument/op_histogram.rs
+++ b/crates/engine/src/profiling/instrument/op_histogram.rs
@@ -1,0 +1,275 @@
+use miden_core::{Felt, operations::Operation};
+
+use super::Instrument;
+
+/// An [`Instrument`] to create operation histograms.
+///
+/// At each cycle, it records the current operation and produces a histogram of executed operations
+/// weighted by cycles per operation. If `opX` takes 4 cycles and was executed twice, its count
+/// will be 8.
+pub struct OpHistogram {
+    total_cycles: u128,
+    counts: [u64; 256],
+}
+
+impl Default for OpHistogram {
+    fn default() -> Self {
+        Self {
+            total_cycles: 0,
+            counts: [0; 256],
+        }
+    }
+}
+
+impl Instrument for OpHistogram {
+    fn name(&self) -> &'static str {
+        "op-histogram"
+    }
+
+    fn on_operation_execution_cycle(&mut self, op: Operation) {
+        self.total_cycles += 1;
+        // `op.op_code` returns u8 which can safely be used as index here
+        self.counts[usize::from(op.op_code())] += 1;
+    }
+
+    fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+        const OP_COL_WIDTH: usize = 16;
+        const SHARE_COL_WIDTH: usize = 7;
+
+        let total = self.total_cycles;
+
+        // Header row: the total accounts for 100% of the cycles. Every row is laid out in three
+        // columns (op | share | count) with fixed widths so the output stays aligned. When `total
+        // == 0` there are no data rows, so only this header line is written.
+        writeln!(
+            writer,
+            "{:<col1$} {:>col2$} {}",
+            "total_cycles",
+            "100%",
+            total,
+            col1 = OP_COL_WIDTH,
+            col2 = SHARE_COL_WIDTH,
+        )?;
+
+        for (op, count) in self.sorted_counts() {
+            let share = 100.0 * (count as f64) / (total as f64);
+            // Any payload on the reconstructed `Operation` is just a meaningless placeholder, so
+            // remove it. The report then only contains `push` instead of `push(0)`, for example.
+            let label = op.to_string();
+            let label = label.split('(').next().unwrap();
+            writeln!(
+                writer,
+                "{:<col1$} {:>col2$} {}",
+                label,
+                format!("{share:.2}%"),
+                count,
+                col1 = OP_COL_WIDTH,
+                col2 = SHARE_COL_WIDTH,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl OpHistogram {
+    fn sorted_counts(&self) -> SortedCounts {
+        let mut counts: SortedCounts = ALL_OPERATIONS
+            .iter()
+            .map(|&op| (op, self.counts[usize::from(op.op_code())]))
+            .filter(|&(_, count)| count > 0)
+            .collect();
+        // Sort by count descending; break ties by opcode for a stable order.
+        counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.op_code().cmp(&b.0.op_code())));
+        counts
+    }
+}
+
+/// Counts per operation, sorted in descending order by count.
+type SortedCounts = Vec<(Operation, u64)>;
+
+/// Every basic-block [`Operation`] variant, with placeholder payloads (`Felt::ZERO`) for the
+/// value-carrying variants. Used to map the `counts` array back into typed operations for
+/// reporting.
+///
+/// A unit test ensures that this list contains *all* relevant operations from `miden-core`.
+const ALL_OPERATIONS: &[Operation] = &[
+    Operation::Noop,
+    Operation::Assert(Felt::ZERO),
+    Operation::SDepth,
+    Operation::Caller,
+    Operation::Clk,
+    Operation::Emit,
+    Operation::Add,
+    Operation::Neg,
+    Operation::Mul,
+    Operation::Inv,
+    Operation::Incr,
+    Operation::And,
+    Operation::Or,
+    Operation::Not,
+    Operation::Eq,
+    Operation::Eqz,
+    Operation::Expacc,
+    Operation::Ext2Mul,
+    Operation::U32split,
+    Operation::U32add,
+    Operation::U32add3,
+    Operation::U32sub,
+    Operation::U32mul,
+    Operation::U32madd,
+    Operation::U32div,
+    Operation::U32and,
+    Operation::U32xor,
+    Operation::U32assert2(Felt::ZERO),
+    Operation::Pad,
+    Operation::Drop,
+    Operation::Dup0,
+    Operation::Dup1,
+    Operation::Dup2,
+    Operation::Dup3,
+    Operation::Dup4,
+    Operation::Dup5,
+    Operation::Dup6,
+    Operation::Dup7,
+    Operation::Dup9,
+    Operation::Dup11,
+    Operation::Dup13,
+    Operation::Dup15,
+    Operation::Swap,
+    Operation::SwapW,
+    Operation::SwapW2,
+    Operation::SwapW3,
+    Operation::SwapDW,
+    Operation::MovUp2,
+    Operation::MovUp3,
+    Operation::MovUp4,
+    Operation::MovUp5,
+    Operation::MovUp6,
+    Operation::MovUp7,
+    Operation::MovUp8,
+    Operation::MovDn2,
+    Operation::MovDn3,
+    Operation::MovDn4,
+    Operation::MovDn5,
+    Operation::MovDn6,
+    Operation::MovDn7,
+    Operation::MovDn8,
+    Operation::CSwap,
+    Operation::CSwapW,
+    Operation::Push(Felt::ZERO),
+    Operation::AdvPop,
+    Operation::AdvPopW,
+    Operation::MLoadW,
+    Operation::MStoreW,
+    Operation::MLoad,
+    Operation::MStore,
+    Operation::MStream,
+    Operation::Pipe,
+    Operation::CryptoStream,
+    Operation::HPerm,
+    Operation::MpVerify(Felt::ZERO),
+    Operation::MrUpdate,
+    Operation::FriE2F4,
+    Operation::HornerBase,
+    Operation::HornerExt,
+    Operation::EvalCircuit,
+    Operation::LogPrecompile,
+];
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use miden_core::{Felt, operations::Operation, serde::Deserializable};
+
+    use super::ALL_OPERATIONS;
+    use crate::profiling::instrument::Instrument;
+
+    /// `ALL_OPERATIONS` must contain exactly the set of opcodes that map to a
+    /// valid `Operation`.
+    ///
+    /// We use `Operation`'s `Deserializable` impl as the source of truth.
+    #[test]
+    fn all_operations_covers_every_valid_opcode() {
+        // The payload-carrying variants (Push, Assert, MpVerify, U32assert2)
+        // read an extra `Felt` after the opcode byte, so pad with enough zero
+        // bytes for them to deserialize. Trailing bytes are ignored by the
+        // reader, so this is harmless for the 1-byte variants.
+        let valid: BTreeSet<u8> = (0u8..=u8::MAX)
+            .filter(|&op| Operation::read_from_bytes(&[op, 0, 0, 0, 0, 0, 0, 0, 0]).is_ok())
+            .collect();
+
+        let ours: BTreeSet<u8> = ALL_OPERATIONS.iter().map(|op| op.op_code()).collect();
+
+        // `ALL_OPERATIONS` holds real `Operation` values, so  `ours ⊆ valid`. The list can
+        // therefore only fall out of sync by *missing* a variant.
+        let missing_in_ours: Vec<String> = valid
+            .difference(&ours)
+            .map(|&op| {
+                format!(
+                    "{}",
+                    Operation::read_from_bytes(&[op, 0, 0, 0, 0, 0, 0, 0, 0])
+                        .expect("valid opcode deserializes to an Operation")
+                )
+            })
+            .collect();
+
+        if !missing_in_ours.is_empty() {
+            panic!(
+                "ALL_OPERATIONS is out of sync with miden-core's Operation enum.\n  missing from \
+                 ALL_OPERATIONS (add these): {missing_in_ours:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn op_histogram_reports_recorded_ops() {
+        let mut hist = super::OpHistogram::default();
+        assert_eq!(hist.name(), "op-histogram");
+
+        // 3 cycles
+        hist.on_operation_execution_cycle(Operation::Add);
+        hist.on_operation_execution_cycle(Operation::Add);
+        hist.on_operation_execution_cycle(Operation::Noop);
+
+        let mut buf = Vec::new();
+        hist.write_report_to(&mut buf).unwrap();
+        let report = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = report.lines().collect();
+        // First line is the header reporting 100% of 3 cycles.
+        assert!(lines[0].contains("total_cycles") && lines[0].contains('3'));
+
+        // `Add` must preceed `Noop`, due to higher count.
+        assert!(lines[1].contains(Operation::Add.to_string().as_str()) && lines[1].contains("2"));
+        assert!(lines[2].contains(Operation::Noop.to_string().as_str()) && lines[2].contains("1"));
+
+        // no further lines
+        assert_eq!(lines.len(), 3);
+    }
+
+    /// Payload-carrying operations must render with just their mnemonic, e.g. `push` rather than
+    /// `push(0)`.
+    #[test]
+    fn op_histogram_omits_payload_from_mnemonic() {
+        let mut hist = super::OpHistogram::default();
+
+        // All payload carrying variants
+        hist.on_operation_execution_cycle(Operation::Push(Felt::ZERO));
+        hist.on_operation_execution_cycle(Operation::Assert(Felt::ZERO));
+        hist.on_operation_execution_cycle(Operation::MpVerify(Felt::ZERO));
+        hist.on_operation_execution_cycle(Operation::U32assert2(Felt::ZERO));
+
+        let mut buf = Vec::new();
+        hist.write_report_to(&mut buf).unwrap();
+        let report = String::from_utf8(buf).unwrap();
+
+        assert!(
+            !report.contains("(0)"),
+            "report must not contain placeholder payloads: {report}"
+        );
+        for mnemonic in ["push", "assert", "mpverify", "u32assert2"] {
+            assert!(report.contains(mnemonic), "report missing `{mnemonic}`: {report}");
+        }
+    }
+}

--- a/crates/engine/src/profiling/instrument/op_histogram.rs
+++ b/crates/engine/src/profiling/instrument/op_histogram.rs
@@ -1,6 +1,6 @@
 use miden_core::{Felt, operations::Operation};
 
-use super::Instrument;
+use super::{INSTRUMENT_NAME_OP_HISTOGRAM, Instrument};
 
 /// An [`Instrument`] to create operation histograms.
 ///
@@ -23,7 +23,7 @@ impl Default for OpHistogram {
 
 impl Instrument for OpHistogram {
     fn name(&self) -> &'static str {
-        "op-histogram"
+        INSTRUMENT_NAME_OP_HISTOGRAM
     }
 
     fn on_operation_execution_cycle(&mut self, op: Operation) {

--- a/crates/engine/src/profiling/mod.rs
+++ b/crates/engine/src/profiling/mod.rs
@@ -3,5 +3,5 @@ pub mod instrument;
 mod profiler;
 
 pub use config::{ProfilerCliArgs, ProfilerConfig};
-pub use instrument::{Instrument, OpHistogram};
+pub use instrument::{INSTRUMENT_NAME_OP_HISTOGRAM, Instrument, OpHistogram, instrument_from_name};
 pub use profiler::Profiler;

--- a/crates/engine/src/profiling/mod.rs
+++ b/crates/engine/src/profiling/mod.rs
@@ -3,5 +3,5 @@ pub mod instrument;
 mod profiler;
 
 pub use config::{ProfilerCliArgs, ProfilerConfig};
-pub use instrument::{INSTRUMENT_NAME_OP_HISTOGRAM, Instrument, OpHistogram, instrument_from_name};
+pub use instrument::{Instrument, InstrumentRegistration, OpHistogram, instrument_from_name};
 pub use profiler::Profiler;

--- a/crates/engine/src/profiling/mod.rs
+++ b/crates/engine/src/profiling/mod.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod instrument;
+mod profiler;
+
+pub use config::{ProfilerCliArgs, ProfilerConfig};
+pub use instrument::{Instrument, OpHistogram};
+pub use profiler::Profiler;

--- a/crates/engine/src/profiling/profiler.rs
+++ b/crates/engine/src/profiling/profiler.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use miden_core::operations::Operation;
+
+use crate::profiling::{ProfilerConfig, instrument::Instrument};
+
+/// Holds the loaded [`Instrument`]s and dispatches event handlers to them.
+///
+/// The default is a no-op `Profiler`.
+#[derive(Default)]
+pub struct Profiler {
+    instruments: Vec<Box<dyn Instrument>>,
+    output_paths: HashMap<&'static str, PathBuf>,
+}
+
+impl Profiler {
+    pub fn from_config(config: ProfilerConfig) -> Self {
+        Self {
+            instruments: config.instruments,
+            output_paths: config.output_paths,
+        }
+    }
+
+    /// Records the op with every active instrument, otherwise it's a no-op.
+    pub fn on_operation_execution_cycle(&mut self, op: Operation) {
+        for instrument in &mut self.instruments {
+            instrument.on_operation_execution_cycle(op);
+        }
+    }
+
+    /// Writes every instrument's report to its configured output file.
+    ///
+    /// Failure to write a report should not abort execution, therefore this function always
+    /// succeeds. If any errors occur they are logged.
+    pub fn write_reports(&self) {
+        for instrument in &self.instruments {
+            let name = instrument.name();
+            let Some(path) = self.output_paths.get(name) else {
+                log::warn!("cannot write report for instrument `{name}`: no output file");
+                continue;
+            };
+            let mut file = match std::fs::File::create(path) {
+                Ok(file) => file,
+                Err(e) => {
+                    log::error!(
+                        "failed to create profiler output file for `{name}` at {}: {e}",
+                        path.display()
+                    );
+                    continue;
+                }
+            };
+            if let Err(e) = instrument.write_report_to(&mut file) {
+                log::error!("failed to write `{name}` report to {}: {e}", path.display());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_core::operations::Operation;
+
+    use super::*;
+    use crate::profiling::ProfilerConfig;
+
+    /// A minimal `Instrument` to test event dispatch.
+    struct CountingInstrument {
+        name: &'static str,
+        ops: u32,
+    }
+
+    impl Instrument for CountingInstrument {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn on_operation_execution_cycle(&mut self, _op: Operation) {
+            self.ops += 1;
+        }
+
+        fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+            writer.write_fmt(format_args!("{}:{}", self.name, self.ops))
+        }
+    }
+
+    #[test]
+    fn profiler_dispatches_events_to_all_instruments() {
+        let config = ProfilerConfig {
+            instruments: vec![
+                Box::new(CountingInstrument { name: "a", ops: 0 }),
+                Box::new(CountingInstrument { name: "b", ops: 0 }),
+            ],
+            ..Default::default()
+        };
+        let mut profiler = Profiler::from_config(config);
+
+        // Each instrument must observe every recorded op.
+        profiler.on_operation_execution_cycle(Operation::Add);
+        profiler.on_operation_execution_cycle(Operation::Noop);
+
+        // Collect each report into an in-memory buffer and construct string from there.
+        fn report_of(instrument: &dyn Instrument) -> String {
+            let mut buf = Vec::new();
+            instrument.write_report_to(&mut buf).unwrap();
+            String::from_utf8(buf).unwrap()
+        }
+
+        let reports: HashMap<&'static str, String> = profiler
+            .instruments
+            .iter()
+            .map(|instrument| (instrument.name(), report_of(instrument.as_ref())))
+            .collect();
+
+        assert_eq!(reports.get("a").unwrap(), "a:2");
+        assert_eq!(reports.get("b").unwrap(), "b:2");
+    }
+}

--- a/crates/engine/src/profiling/profiler.rs
+++ b/crates/engine/src/profiling/profiler.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use miden_core::operations::Operation;
 
@@ -10,14 +10,14 @@ use crate::profiling::{ProfilerConfig, instrument::Instrument};
 #[derive(Default)]
 pub struct Profiler {
     instruments: Vec<Box<dyn Instrument>>,
-    output_paths: HashMap<&'static str, PathBuf>,
+    reports_dir: Option<PathBuf>,
 }
 
 impl Profiler {
     pub fn from_config(config: ProfilerConfig) -> Self {
         Self {
             instruments: config.instruments,
-            output_paths: config.output_paths,
+            reports_dir: config.reports_dir,
         }
     }
 
@@ -28,18 +28,32 @@ impl Profiler {
         }
     }
 
-    /// Writes every instrument's report to its configured output file.
+    /// Writes every instrument's report to the configured reports output directory.
     ///
     /// Failure to write a report should not abort execution, therefore this function always
     /// succeeds. If any errors occur they are logged.
     pub fn write_reports(&self) {
+        if self.instruments.is_empty() {
+            return;
+        }
+
+        let Some(ref reports_dir) = self.reports_dir else {
+            log::warn!("cannot write profiler reports: no reports directory configured");
+            return;
+        };
+
+        if let Err(e) = std::fs::create_dir_all(reports_dir) {
+            log::error!(
+                "failed to create profiler reports directory {}: {e}",
+                reports_dir.display()
+            );
+            return;
+        }
+
         for instrument in &self.instruments {
             let name = instrument.name();
-            let Some(path) = self.output_paths.get(name) else {
-                log::warn!("cannot write report for instrument `{name}`: no output file");
-                continue;
-            };
-            let mut file = match std::fs::File::create(path) {
+            let path = reports_dir.join(name);
+            let mut file = match std::fs::File::create(&path) {
                 Ok(file) => file,
                 Err(e) => {
                     log::error!(
@@ -58,6 +72,8 @@ impl Profiler {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use miden_core::operations::Operation;
 
     use super::*;
@@ -81,6 +97,40 @@ mod tests {
         fn write_report_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
             writer.write_fmt(format_args!("{}:{}", self.name, self.ops))
         }
+    }
+
+    #[test]
+    fn profiler_writes_reports_to_directory() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        let config = ProfilerConfig {
+            instruments: vec![
+                Box::new(CountingInstrument {
+                    name: "alpha",
+                    ops: 0,
+                }),
+                Box::new(CountingInstrument {
+                    name: "beta",
+                    ops: 0,
+                }),
+            ],
+            reports_dir: Some(tmp_dir.path().to_path_buf()),
+        };
+        let mut profiler = Profiler::from_config(config);
+
+        // Record some operations so the instruments have data to report.
+        profiler.on_operation_execution_cycle(Operation::Add);
+        profiler.on_operation_execution_cycle(Operation::Noop);
+        profiler.on_operation_execution_cycle(Operation::Add);
+
+        profiler.write_reports();
+
+        // Verify files were created with expected content.
+        let alpha_content = std::fs::read_to_string(tmp_dir.path().join("alpha")).unwrap();
+        assert_eq!(alpha_content, "alpha:3");
+
+        let beta_content = std::fs::read_to_string(tmp_dir.path().join("beta")).unwrap();
+        assert_eq!(beta_content, "beta:3");
     }
 
     #[test]

--- a/docs/external/src/profiling.md
+++ b/docs/external/src/profiling.md
@@ -1,0 +1,34 @@
+---
+title: Profiling
+sidebar_position: 10
+---
+
+# Profiling
+
+Profiling generates an execution profile that shows which operations consume the most cycles. This helps identify hotspots in Miden Assembly programs.
+
+## Usage
+
+Run the debugger with `--commands` to execute a script and `--profile-op-histogram-out` to collect and write the profile:
+
+```bash
+miden-debug \
+    --profile-op-histogram-out ./op_histogram.txt \
+    --commands cmds.txt \
+    fibonacci:fibonacci.masp -- 42
+```
+
+The `cmds.txt` script should contain:
+
+```text
+# Run until completion
+continue
+# Optionally print stack outputs
+stack
+```
+
+Once passing commands as CLI parameters is supported [[#97](https://github.com/0xMiden/miden-debug/issues/97)], no separate `cmds.txt` file will be needed.
+
+## Interpretation
+
+The output file contains a histogram of operation counts sorted by frequency. Counts are weighted by cycle, so if `opx` takes 4 cycles and is executed twice, its value in the histogram will be 8.

--- a/docs/external/src/profiling.md
+++ b/docs/external/src/profiling.md
@@ -9,11 +9,16 @@ Profiling generates an execution profile that shows which operations consume the
 
 ## Usage
 
-Run the debugger with `--commands` to execute a script and `--profile-op-histogram-out` to collect and write the profile:
+Run the debugger with
+
+- `--commands` to execute a script
+- `--profiling-reports-dir` to set the output directory
+- and `--profiling-instruments` to enable one or more profiling instruments
 
 ```bash
 miden-debug \
-    --profile-op-histogram-out ./op_histogram.txt \
+    --profiling-reports-dir ./reports \
+    --profiling-instruments op-histogram \
     --commands cmds.txt \
     fibonacci:fibonacci.masp -- 42
 ```
@@ -28,6 +33,8 @@ stack
 ```
 
 Once passing commands as CLI parameters is supported [[#97](https://github.com/0xMiden/miden-debug/issues/97)], no separate `cmds.txt` file will be needed.
+
+Reports are written to the directory specified by `--profiling-reports-dir`, with one file per instrument named after the instrument (e.g., `op-histogram`).
 
 ## Interpretation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use miden_debug_engine::LinkLibrary;
+use miden_debug_engine::{LinkLibrary, profiling::ProfilerCliArgs};
 
 use crate::{exec::ExecutionConfig, felt::Felt, input::InputFile};
 
@@ -194,6 +194,12 @@ pub struct DebuggerConfig {
     #[cfg(feature = "python")]
     #[cfg_attr(feature = "python", arg(long, help_heading = "Scripting"))]
     pub no_user_python_init: bool,
+    /// Profiler configuration.
+    #[cfg_attr(
+        any(feature = "tui", feature = "repl", feature = "flamegraph"),
+        command(flatten)
+    )]
+    pub profiler_cli_args: ProfilerCliArgs,
 }
 
 /// ColorChoice represents the color preferences of an end user.

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -214,6 +214,7 @@ impl FlamegraphArgs {
             replay: None,
             #[cfg(feature = "python")]
             no_user_python_init: true,
+            profiler_cli_args: Default::default(), // disable profiling
         }
     }
 }

--- a/src/program_loader.rs
+++ b/src/program_loader.rs
@@ -40,7 +40,7 @@ pub(crate) fn load_debug_executor(
 
     let mut executor = Executor::new(args).with_registry(registry);
     executor
-        .with_profiler_config(config.profiler_cli_args.clone().into())
+        .with_profiler_config(config.profiler_cli_args.clone().try_into()?)
         .with_advice_inputs(inputs.advice_inputs);
 
     Ok(executor.into_debug(package, source_manager))

--- a/src/program_loader.rs
+++ b/src/program_loader.rs
@@ -39,7 +39,9 @@ pub(crate) fn load_debug_executor(
     let package = load_package(config)?;
 
     let mut executor = Executor::new(args).with_registry(registry);
-    executor.with_advice_inputs(inputs.advice_inputs);
+    executor
+        .with_profiler_config(config.profiler_cli_args.clone().into())
+        .with_advice_inputs(inputs.advice_inputs);
 
     Ok(executor.into_debug(package, source_manager))
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -113,7 +113,7 @@ impl RemoteState {
     fn connect(addr: &str, source_manager: &Arc<dyn SourceManager>) -> Result<Self, Report> {
         use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
-        use miden_debug_engine::debug::DebugVarTracker;
+        use miden_debug_engine::{debug::DebugVarTracker, profiling::Profiler};
         use miden_processor::{ContextId, FastProcessor};
 
         use crate::exec::DebuggerHost;
@@ -141,6 +141,7 @@ impl RemoteState {
             recent: VecDeque::new(),
             cycle: snapshot.cycle,
             stopped: false,
+            profiler: Profiler::default(),
         };
 
         Ok(Self {

--- a/tests/lit/op_histogram.test
+++ b/tests/lit/op_histogram.test
@@ -1,0 +1,18 @@
+# Smoke test: generate an op histogram from a trivial program.
+# The histogram file should contain a total_cycles header and one row per
+# executed operation, sorted by descending cycle count.
+#
+# RUN: compile-masm %S/add.masm -o %t.masp
+# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+
+continue
+stack
+
+# CHECK: Program terminated successfully
+# CHECK: [0] 7
+# CHECK: total_cycles        100% 11
+# CHECK-NEXT: push              36.36% 4
+# CHECK-NEXT: noop              27.27% 3
+# CHECK-NEXT: add               18.18% 2
+# CHECK-NEXT: drop               9.09% 1
+# CHECK-NEXT: mstore             9.09% 1

--- a/tests/lit/op_histogram.test
+++ b/tests/lit/op_histogram.test
@@ -3,7 +3,11 @@
 # executed operation, sorted by descending cycle count.
 #
 # RUN: compile-masm %S/add.masm -o %t.masp
-# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+# RUN: (miden-debug \
+# RUN:   --profiling-reports-dir %t_reports \
+# RUN:   --profiling-instruments op-histogram \
+# RUN:   --commands %s %t.masp 2>&1; \
+# RUN:  cat %t_reports/op-histogram) | filecheck %s
 
 continue
 stack

--- a/tests/lit/op_histogram_arithmetic.masm
+++ b/tests/lit/op_histogram_arithmetic.masm
@@ -1,0 +1,34 @@
+# Exercises a variety of operations: arithmetic, comparison, bitwise, memory,
+# and stack manipulation. The final result (20) is left on top of the stack.
+begin
+    # arithmetic: (7 + 3) * 2 = 20
+    push.7
+    push.3
+    add
+    push.2
+    mul
+
+    # save result to memory before comparison (which consumes both operands)
+    push.0
+    mem_store
+
+    # comparison: 10 == 10 -> 1 (true)
+    push.10
+    push.10
+    eq
+    drop
+    drop
+    drop
+
+    # bitwise: 0xFF & 0x0F = 0x0F = 15
+    push.0xFF
+    push.0x0F
+    u32and
+    drop
+    drop
+
+    # load the saved result and `add` intto padding 0 on stack to keep final stack size in bounds
+    push.0
+    mem_load
+    add
+end

--- a/tests/lit/op_histogram_arithmetic.test
+++ b/tests/lit/op_histogram_arithmetic.test
@@ -1,0 +1,22 @@
+# Final stack of the program: [0] 20.
+#
+# RUN: compile-masm %S/op_histogram_arithmetic.masm -o %t.masp
+# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+
+continue
+stack
+
+# CHECK: Program terminated successfully
+# CHECK: [0] 20
+# The program executes 30 cycles across 10 distinct operations.
+# CHECK: total_cycles        100% 30
+# CHECK-NEXT: push              30.00% 9
+# CHECK-NEXT: drop              23.33% 7
+# CHECK-NEXT: noop              13.33% 4
+# CHECK-NEXT: add                6.67% 2
+# CHECK-NEXT: mstore             6.67% 2
+# CHECK-NEXT: pad                6.67% 2
+# CHECK-NEXT: mload              3.33% 1
+# CHECK-NEXT: eq                 3.33% 1
+# CHECK-NEXT: mul                3.33% 1
+# CHECK-NEXT: u32and             3.33% 1

--- a/tests/lit/op_histogram_arithmetic.test
+++ b/tests/lit/op_histogram_arithmetic.test
@@ -1,7 +1,11 @@
 # Final stack of the program: [0] 20.
 #
 # RUN: compile-masm %S/op_histogram_arithmetic.masm -o %t.masp
-# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+# RUN: (miden-debug \
+# RUN:   --profiling-reports-dir %t_reports \
+# RUN:   --profiling-instruments op-histogram \
+# RUN:   --commands %s %t.masp 2>&1; \
+# RUN:  cat %t_reports/op-histogram) | filecheck %s
 
 continue
 stack

--- a/tests/lit/op_histogram_loop.masm
+++ b/tests/lit/op_histogram_loop.masm
@@ -1,0 +1,27 @@
+# Computes 1+2+...+10 = 55 using a while loop, then adds the initial push.10.
+# The final result (65) is left on the stack.
+proc sum_to_n
+    push.0
+    push.1
+    while.true
+        dup
+        push.11
+        neq
+        if.true
+            dup
+            movup.2
+            add
+            swap
+            add.1
+            push.1
+        else
+            push.0
+        end
+    end
+    drop
+end
+begin
+    push.10
+    exec.sum_to_n
+    add
+end

--- a/tests/lit/op_histogram_loop.test
+++ b/tests/lit/op_histogram_loop.test
@@ -1,0 +1,21 @@
+# RUN: compile-masm %S/op_histogram_loop.masm -o %t.masp
+# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+
+continue
+stack
+
+# CHECK: Program terminated successfully
+# CHECK: [0] 65
+# CHECK: total_cycles        100% 137
+# CHECK-NEXT: incr              16.79% 23
+# CHECK-NEXT: dup0              16.79% 23
+# CHECK-NEXT: push              10.95% 15
+# CHECK-NEXT: pad               10.22% 14
+# CHECK-NEXT: not                8.76% 12
+# CHECK-NEXT: eq                 8.76% 12
+# CHECK-NEXT: add                8.76% 12
+# CHECK-NEXT: swap               8.03% 11
+# CHECK-NEXT: movup2             8.03% 11
+# CHECK-NEXT: drop               1.46% 2
+# CHECK-NEXT: noop               0.73% 1
+# CHECK-NEXT: mstore             0.73% 1

--- a/tests/lit/op_histogram_loop.test
+++ b/tests/lit/op_histogram_loop.test
@@ -1,5 +1,9 @@
 # RUN: compile-masm %S/op_histogram_loop.masm -o %t.masp
-# RUN: (miden-debug --profile-op-histogram-out %t.histogram --commands %s %t.masp 2>&1; cat %t.histogram) | filecheck %s
+# RUN: (miden-debug \
+# RUN:   --profiling-reports-dir %t_reports \
+# RUN:   --profiling-instruments op-histogram \
+# RUN:   --commands %s %t.masp 2>&1; \
+# RUN:  cat %t_reports/op-histogram) | filecheck %s
 
 continue
 stack

--- a/tests/lit/profiling_errors.test
+++ b/tests/lit/profiling_errors.test
@@ -1,0 +1,36 @@
+# Tests for invalid profiling CLI argument combinations.
+#
+# First, compile a trivial program so we have a .masp to pass.
+# RUN: compile-masm %S/add.masm -o %t.masp
+#
+# Case 1: --profiling-reports-dir points to a file, not a directory.
+# RUN: touch %t.regular_file
+# RUN: miden-debug \
+# RUN:   --profiling-reports-dir %t.regular_file \
+# RUN:   --profiling-instruments op-histogram \
+# RUN:   --commands %s %t.masp 2>&1 | filecheck %s --check-prefix=ERR-FILE
+#
+# Case 2: --profiling-reports-dir set but no instruments specified.
+# RUN: mkdir -p %t_reports
+# RUN: miden-debug \
+# RUN:   --profiling-reports-dir %t_reports \
+# RUN:   --commands %s %t.masp 2>&1 | filecheck %s --check-prefix=ERR-NO-INSTR
+#
+# Case 3: --profiling-instruments set but no reports dir.
+# RUN: miden-debug \
+# RUN:   --profiling-instruments op-histogram \
+# RUN:   --commands %s %t.masp 2>&1 | filecheck %s --check-prefix=ERR-NO-DIR
+#
+# Case 4: Unknown instrument name.
+# RUN: mkdir -p %t_reports2
+# RUN: miden-debug \
+# RUN:   --profiling-reports-dir %t_reports2 \
+# RUN:   --profiling-instruments bogus-instrument \
+# RUN:   --commands %s %t.masp 2>&1 | filecheck %s --check-prefix=ERR-UNKNOWN
+
+continue
+
+# ERR-FILE: x invalid profiling reports directory
+# ERR-NO-INSTR: x profiling requires at least one instrument
+# ERR-NO-DIR: x profiling instruments require --profiling-reports-dir
+# ERR-UNKNOWN: x unknown profiling instrument 'bogus-instrument'


### PR DESCRIPTION
Usage is described in `profiling.md`. For the global histogram no instrumentation of the Masp is required.

#### `ProfEngine`

Currently it may seem like overkill. It's intention is centralizing profiling logic in the `prof` module. I expect this to pay off when we follow-up with adding more profiling modes (histograms per function, ...).

#### Example

This is the histogram of executing `compiler/examples/fibonacci` with input 99. ~Note that `(0)` as in `push(0)` is just a placeholder for printing the mandatory argument of some ops. We may want to clear this out from the report.~

```
total_cycles        100% 2897
push           26.65% 772
mload             18.92% 548
add               12.81% 371
drop              11.53% 334
mstore             6.70% 194
dup0               4.42% 128
swap               4.11% 119
u32add             3.94% 114
pad                3.00% 87
noop               2.69% 78
incr               1.62% 47
not                0.69% 20
eq                 0.69% 20
u32and             0.59% 17
cswap              0.55% 16
movup3             0.52% 15
movup2             0.17% 5
movdn3             0.07% 2
mstorew            0.07% 2
eqz                0.03% 1
swapw              0.03% 1
swapw2             0.03% 1
swapw3             0.03% 1
mloadw             0.03% 1
sdepth             0.03% 1
u32sub             0.03% 1
u32assert2      0.03% 1
```