### PR TITLE
fix: forward events to builtin handlers even with event replay

### DIFF
--- a/crates/engine/src/exec/event.rs
+++ b/crates/engine/src/exec/event.rs
@@ -100,13 +100,13 @@ impl Event {
             Self::Unknown(_) => return None,
         })
     }
-}
 
-/// Returns true if `id` corresponds to a builtin debugger event.
-pub fn is_builtin_event(id: EventId) -> bool {
-    match Event::from(id) {
-        Event::FrameStart | Event::FrameEnd | Event::PrintLn => true,
-        Event::Unknown(_) | Event::UserDefined(_) => false,
+    /// Returns `true` if `DebuggerHost` has a builtin handler for the event.
+    pub fn has_builtin_handler(&self) -> bool {
+        match self {
+            Self::FrameStart | Self::FrameEnd | Self::PrintLn => true,
+            Self::UserDefined(_) | Self::Unknown(_) => false,
+        }
     }
 }
 

--- a/crates/engine/src/exec/event.rs
+++ b/crates/engine/src/exec/event.rs
@@ -102,6 +102,14 @@ impl Event {
     }
 }
 
+/// Returns true if `id` corresponds to a builtin debugger event.
+pub fn is_builtin_event(id: EventId) -> bool {
+    match Event::from(id) {
+        Event::FrameStart | Event::FrameEnd | Event::PrintLn => true,
+        Event::Unknown(_) | Event::UserDefined(_) => false,
+    }
+}
+
 impl core::fmt::Display for Event {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -382,6 +382,8 @@ fn register_builtin_event_handlers(
         Ok(vec![])
     };
 
+    // Keep builtin event handlers in sync with `Event::has_builtin_handler`
+
     host.register_event_handler(PRINTLN_EVENT, Arc::new(println_handler))
         .expect("failed to register println event handler");
 

--- a/crates/engine/src/exec/executor.rs
+++ b/crates/engine/src/exec/executor.rs
@@ -613,6 +613,44 @@ mod tests {
         assert_eq!(replayed_result, recorded_result);
     }
 
+    /// Replayed builtin events still reach their handlers so debugger state remains available.
+    #[test]
+    fn replay_invokes_builtin_event_handlers() {
+        use miden_assembly::DefaultSourceManager;
+
+        let source_manager: Arc<DefaultSourceManager> = Arc::new(DefaultSourceManager::default());
+        let program = miden_assembly::Assembler::new(source_manager.clone())
+            .assemble_program(
+                "program",
+                format!(
+                    r#"
+begin
+    emit.event("{FRAME_START_EVENT}")
+    emit.event("{FRAME_START_EVENT}")
+end
+"#
+                ),
+            )
+            .map(Arc::<Package>::from)
+            .expect("failed to assemble test program");
+
+        let event_replay = VecDeque::from([Vec::new(), Vec::new()]);
+        let mut debug_executor = Executor::new(Vec::new()).into_debug_with_replay(
+            program,
+            source_manager,
+            Vec::new(),
+            event_replay,
+        );
+        while !debug_executor.stopped {
+            debug_executor.step().expect("replay step failed");
+        }
+
+        assert!(
+            debug_executor.callstack.frames().len() >= 2,
+            "expected replayed frame-start events to update the debugger call stack"
+        );
+    }
+
     /// A recorded execution serialized into a [ReplaySnapshot](crate::exec::ReplaySnapshot) and
     /// read back from bytes replays to the same result — the offline record→replay path, end to
     /// end, exactly what `miden-debug --replay <snapshot>` drives.

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -15,6 +15,7 @@ use miden_processor::{
 };
 
 use super::advice::clone_advice_mutations;
+use crate::event::is_builtin_event;
 
 /// This is an implementation of [Host] which is essentially [miden_processor::DefaultHost],
 /// but extended with additional functionality for debugging, in particular it manages trace
@@ -153,12 +154,27 @@ where
         &mut self,
         process: &ProcessorState<'_>,
     ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        if !self.event_replay.is_empty() {
-            let mutations = self.event_replay.pop_front().unwrap_or_default();
-            return std::future::ready(Ok(mutations));
+        let event_id = EventId::from_felt(process.get_stack_item(0));
+        let is_builtin_event = is_builtin_event(event_id);
+        let replay_mutations = self.event_replay.pop_front();
+        let is_replaying = replay_mutations.is_some();
+
+        if let Some(mutations) = replay_mutations {
+            if !is_builtin_event {
+                // Non-debug events without builtin handler: return mutations from replay.
+                return std::future::ready(Ok(mutations));
+            }
+
+            // Even in replay mode we want to forward builtin events to the builtin handlers.
+            // Debugger functionality relies on the side effects of the handlers.
+            if is_builtin_event {
+                assert!(
+                    mutations.is_empty(),
+                    "debug events must not be associated with mutations from replay"
+                );
+            }
         }
 
-        let event_id = EventId::from_felt(process.get_stack_item(0));
         let result = match self.event_handlers.handle_event(event_id, process) {
             Ok(Some(mutations)) => Ok(mutations),
             Ok(None) => {
@@ -170,7 +186,10 @@ where
             }
             Err(err) => Err(err),
         };
-        if let (Some(log), Ok(mutations)) = (self.event_recording.as_mut(), &result) {
+
+        if !is_replaying
+            && let (Some(log), Ok(mutations)) = (self.event_recording.as_mut(), &result)
+        {
             log.push(clone_advice_mutations(mutations));
         }
         std::future::ready(result)

--- a/crates/engine/src/exec/host.rs
+++ b/crates/engine/src/exec/host.rs
@@ -15,7 +15,7 @@ use miden_processor::{
 };
 
 use super::advice::clone_advice_mutations;
-use crate::event::is_builtin_event;
+use crate::Event;
 
 /// This is an implementation of [Host] which is essentially [miden_processor::DefaultHost],
 /// but extended with additional functionality for debugging, in particular it manages trace
@@ -155,7 +155,7 @@ where
         process: &ProcessorState<'_>,
     ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
         let event_id = EventId::from_felt(process.get_stack_item(0));
-        let is_builtin_event = is_builtin_event(event_id);
+        let is_builtin_event = Event::from(event_id).has_builtin_handler();
         let replay_mutations = self.event_replay.pop_front();
         let is_replaying = replay_mutations.is_some();
 


### PR DESCRIPTION
Closes #84 